### PR TITLE
Remove usage of content.description from documentation

### DIFF
--- a/src/components/docs/external/components/ContentWrapper/ContentWrapper.component.js
+++ b/src/components/docs/external/components/ContentWrapper/ContentWrapper.component.js
@@ -90,7 +90,6 @@ const ContentWrapper = ({ content }) => {
                   </div>
                 );
               })}
-            <Text>{content.description}</Text>
           </ContentDescription>
         </Wrapper>
       )}


### PR DESCRIPTION
Confirm these statements before you submit your pull request:

- [x] I have read and submitted the required [Contributor Licence Agreements](https://github.com/kyma-project/community/blob/master/CONTRIBUTING.md#agreements-and-licenses).
- [x] This pull request follows the contributing guidelines, recommended Git workflow, and templates.
- [x] I have tested my changes.
- [ ] I have updated the relevant documentation.
---

**Description**

Changes proposed in this pull request:

- Remove usage of `content.description` from documentation

**Issue link**
Fixes #22 
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
