### PR TITLE
Add spectral ruleset for website banner

### DIFF
--- a/content/banner/.spectral.yml
+++ b/content/banner/.spectral.yml
@@ -1,0 +1,52 @@
+rules:
+  banner-text-length:
+    description: Text cannot be longer than 120 characters as it will display wrong in the UI.
+    given: $.slides[*]
+    severity: error
+    recommended: true
+    then:
+      field: text
+      function: length
+      functionOptions:
+        max: 120
+  banner-duration:
+    description: It is recommended to set 3-5 sec for banner duration otherwise people won't notice all slides. And yeah, remember, it must be integer value.
+    given: $
+    severity: warn
+    recommended: true
+    then:
+      field: bannerDuration
+      function: schema
+      functionOptions:
+        schema:
+          type: integer
+          minimum: 3000
+          maximum: 5000
+  banner-slides-required-fields:
+    description: You are missing one of required attributes from a slides object. Must have is text, endDate, startDate and url.
+    given: $
+    severity: error
+    recommended: true
+    then:
+      field: slides
+      function: schema
+      functionOptions:
+        schema:
+          type: array
+          items:
+            type: object
+            required:
+              - text
+              - endDate
+              - startDate
+              - url
+  banner-url-valid:
+    description: URL must point to a website over https
+    given: $.slides[*]
+    severity: error
+    recommended: true
+    then:
+      field: url
+      function: pattern
+      functionOptions:
+        match: ^(https:\/\/)?([\da-z\.-]+)\.([a-z\.]{2,6})([\/\w \.-]*)*\/?$


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Add spectral ruleset for website banner

---
The purpose of this PR is to open discussion about how we could use spectral as a default tool for any linting of JSON and YAML files in any area of Kyma:
- OpenAPI spec files
- Kubernetes resources files
- K8s CRDs to follow guidelines
- Things on Kyma website, like the banner from this PR

Spectral positions itself as an OpenAPI linter https://stoplight.io/open-source/spectral/ but it is much more than that. You can define any rules you want for any time of JSON/YAML files https://stoplight.io/p/docs/gh/stoplightio/spectral/docs/getting-started/rulesets.md

To play with it:
```
npm install -g @stoplight/spectral
git clone --single-branch --branch spectral-poc https://github.com/derberg/website
cd website/content/banner
spectral lint slides.yml -r .spectral.yml -v
#now break something in the slides.yml and check out how it works again
spectral lint slides.yml -r .spectral.yml -v
```

Let us hold a discussion about the idea and the tool in this PR