### PR TITLE
Add the reference to the migration guide to the 1.6 release notes

### DIFF
--- a/content/blog-posts/2019-10-18-release-notes-1.6/index.md
+++ b/content/blog-posts/2019-10-18-release-notes-1.6/index.md
@@ -29,7 +29,7 @@ See the overview of all changes in this release:
 - [Service Management](#service-management) - Service Catalog switched to the CRD implementation, GCP Service Broker no longer in the preview mode
 - [Service Mesh](#service-mesh) - Istio updated to 1.2.7
 
->**CAUTION:** Before you upgrade to Kyma 1.6, read the [Migration Guide](https://github.com/kyma-project/kyma/blob/release-1.6/docs/migration-guides/1.5-1.6.md) which describes necessary  actions required by the Service Catalog.
+>**CAUTION:** Before you upgrade to Kyma 1.6, read the [Migration Guide](https://github.com/kyma-project/kyma/blob/release-1.6/docs/migration-guides/1.5-1.6.md) which describes necessary actions required by the Service Catalog.
 
 ## API Gateway
 
@@ -163,7 +163,7 @@ After a couple of months of hard work with development and integrations in the u
     - requested by 43% (from 350m to 200m)
     - limits by 75% (from 800m to 200m)
 
-See [this](https://svc-cat.io/docs/design/#service-catalog-design) document for more information about the new Service Catalog design. What is more, in this release we provided a migration job that handles managed Service Catalog data upgrade between 1.5 and 1.6 Kyma versions. For more information, read [this](https://svc-cat.io/docs/migration-apiserver-to-crds/) document, as well as the [migration guide](https://github.com/kyma-project/kyma/blob/release-1.6/docs/migration-guides/1.5-1.6.md).
+See [this](https://svc-cat.io/docs/design/#service-catalog-design) document for more information about the new Service Catalog design. What is more, in this release we provided a migration job that handles managed Service Catalog data upgrade between 1.5 and 1.6 Kyma versions. For more information, read [this](https://svc-cat.io/docs/migration-apiserver-to-crds/) document as well as the [migration guide](https://github.com/kyma-project/kyma/blob/release-1.6/docs/migration-guides/1.5-1.6.md).
 
 
 ### GCP Service Broker no longer in the preview mode

--- a/content/blog-posts/2019-10-18-release-notes-1.6/index.md
+++ b/content/blog-posts/2019-10-18-release-notes-1.6/index.md
@@ -19,29 +19,29 @@ We can't even imagine a better time to visit Munich than October. While the capi
 See the overview of all changes in this release:
 - [API Gateway](#api-gateway) - Brand new API Gateway
 - [Console](#console) - Simplified Logging UI, Preloading micro frontends
-- [Compass](#compass) - Introducing Compass 
+- [Compass](#compass) - Introducing Compass
 - [Core and Supporting](#core-and-supporting) -  Support for AsyncAPI 2.0 specification, AsyncAPI UI component restyled, support for more Gateway modes by Asset Store, metrics exposed for Asset Store and Headless CMS
 - [Documentation](#documentation) - Improved installation documentation, added troubleshooting guide for Backup
-- [Eventing](#eventing) - Knative Eventing Channel Provisioners replaced with Channel CRD Controllers, Knative Eventing chart updated to 0.8 
-- [Hydroform](#hydroform) - Introducing Hydroform - Kubernetes provisioning 
+- [Eventing](#eventing) - Knative Eventing Channel Provisioners replaced with Channel CRD Controllers, Knative Eventing chart updated to 0.8
+- [Hydroform](#hydroform) - Introducing Hydroform - Kubernetes provisioning
 - [Logging](#serverless) - Added support for Fluent Bit
-- [Serverless](#serverless) - Function Controller enhanced with new features, Knative Serving updated to 0.8.1 
+- [Serverless](#serverless) - Function Controller enhanced with new features, Knative Serving updated to 0.8.1
 - [Service Management](#service-management) - Service Catalog switched to the CRD implementation, GCP Service Broker no longer in the preview mode
 - [Service Mesh](#service-mesh) - Istio updated to 1.2.7
 
+>**CAUTION:** Before you upgrade to Kyma 1.6, read the [Migration Guide](https://github.com/kyma-project/kyma/blob/release-1.6/docs/migration-guides/1.5-1.6.md) which describes necessary  actions required by the Service Catalog.
 
-
-## API Gateway 
+## API Gateway
 
 ### Brand new API Gateway
 
 This release introduces a brand new [API Gateway](https://kyma-project.io/docs/1.6/components/api-gateway-v2/) for you to try out. It aims at replacing the old implementation, but before this happens, the two run side by side in Kyma. Since the API Gateway is still under development, you can find its source code in the Kyma Incubator. A new [`apirules.gateway.kyma-project.io`](https://kyma-project.io/docs/1.6/components/api-gateway-v2/#custom-resource-api-rule) CRD supports interacting with the new API Gateway. You can also expose your services and secure them with either OAuth2 scopes or JSON Web Tokens. Follow [this](https://kyma-project.io/docs/1.6/components/api-gateway-v2/#tutorials-expose-and-secure-a-service) tutorial to learn how.
 
-## Console 
+## Console
 
-### Simplified Logging UI 
+### Simplified Logging UI
 
-Kyma 1.6 comes with a completely refurbished Logging UI. Its simplified view displays only one log stream with log lines matching selected filters. To keep you up to date, the log stream refreshes automatically until you choose to pause it. To ensure a user-friendly experience and intuitive design, the advanced options remain hidden. 
+Kyma 1.6 comes with a completely refurbished Logging UI. Its simplified view displays only one log stream with log lines matching selected filters. To keep you up to date, the log stream refreshes automatically until you choose to pause it. To ensure a user-friendly experience and intuitive design, the advanced options remain hidden.
 
 ![Logging UI](./logging-ui-main.png)
 
@@ -60,7 +60,7 @@ We attach great importance to Kyma performance, constantly striving to speed thi
 Compass is a central, multi-tenant system that allows you to connect Applications and manage them across multiple Kyma Runtimes. Read the [documentation](https://kyma-project.io/docs/1.6/components/compass/) to learn how to enable this experimental component and try it out.
 
 
-### Authorization and authentication 
+### Authorization and authentication
 
 To ensure secure communication between Compass, Runtimes, and Applications we provide you with several authentication and authorization options. To learn more, read [this](https://github.com/kyma-incubator/compass/blob/master/docs/architecture/authentication-and-authorization.md) document.
 
@@ -72,7 +72,7 @@ Only three weeks after its official release, [AsyncAPI 2.0](https://twitter.com/
 
 Although you can register any AsyncAPI version in Kyma, 2.0 is the only specification supported in the Kyma cluster. To make sure you are using the right version, we automatically validate your specification and convert it to 2.0.  
 
-Upgrading from Kyma 1.5 to 1.6 means the cluster has already the new configuration for the Headless CMS component. This means, the AsyncAPI specifications you registered before the upgrade will be automatically converted to the version 2.0. 
+Upgrading from Kyma 1.5 to 1.6 means the cluster has already the new configuration for the Headless CMS component. This means, the AsyncAPI specifications you registered before the upgrade will be automatically converted to the version 2.0.
 
 >**NOTE:** Your specification won’t be converted if version 1.0 is corrupted.
 
@@ -81,7 +81,7 @@ To get even more insight into the topic, check our [demo](https://youtu.be/9tJOn
 
 ### AsyncAPI UI component restyled
 
-We restyled the existing UI component to match SAP Fiori 3 and updated the component to exclusively support AsyncAPI 2.0. The expandable sections improve the overall user experience, making it easier to navigate through documents. 
+We restyled the existing UI component to match SAP Fiori 3 and updated the component to exclusively support AsyncAPI 2.0. The expandable sections improve the overall user experience, making it easier to navigate through documents.
 
 ![Collapsible sections](./collapsible-sections.png)
 
@@ -104,9 +104,9 @@ You can also start exploring metrics right away, using our pre-configured Grafan
 
 ![Grafana dashboard](./grafana-dashboard.png)
 
-## Documentation 
+## Documentation
 
-### Improved installation documentation 
+### Improved installation documentation
 
 We want our documentation to be comprehensive, yet easy to follow and understand. That's why we constantly improve it, always with the community feedback in mind. Our [most recent discussions](https://kyma-community.slack.com/archives/CD2HJ0E78/p1568721087011100) turned out to be a great starting point for another successful implementation. Check out [this](https://kyma-project.io/docs/1.6/root/kyma/#installation-install-kyma-on-a-cluster) installation document to explore the new structure.
 
@@ -116,7 +116,7 @@ We are aware of potential issues that may occur from time to time. That's why ou
 
 ## Eventing
 
-### Knative Eventing replaced Channel Provisioners with Channel CRD controllers 
+### Knative Eventing replaced Channel Provisioners with Channel CRD controllers
 
 In the past, Knative Eventing introduced the general concept of Channel Provisioners. This concept assumed no concrete types for different channel implementations, such as NATS Streaming vs Kafka. Along with Knative Eventing 0.8, Channel Provisioners were deprecated and replaced with [Channel CRD](https://knative.dev/v0.8-docs/eventing/channels/channels-crds/) controllers. In Kyma 1.6, we updated our Event Bus implementation to use the new Channel CRDs. For more details on the recent updates in the Eventing architecture, read [this](https://kyma-project.io/docs/1.6/components/event-bus/#architecture-architecture) document.
 
@@ -133,29 +133,29 @@ This release brings you [Hydroform](https://github.com/kyma-incubator/hydroform/
 
 ## Logging
 
-### Added support for Fluent Bit 
+### Added support for Fluent Bit
 
 So far, Loki came with the default [Promtail](https://github.com/grafana/loki) log collector configuration. From this release, Kyma supports [Fluent Bit](https://fluentbit.io/) as a yet another log collector.
 
 
 ## Serverless
 
-### Function Controller enhanced with new features 
+### Function Controller enhanced with new features
 
-The recent enhancements and fixes introduced to the [Function Controller](https://github.com/kyma-project/kyma/tree/master/components/function-controller) bring it even closer to become production-ready. 
+The recent enhancements and fixes introduced to the [Function Controller](https://github.com/kyma-project/kyma/tree/master/components/function-controller) bring it even closer to become production-ready.
 
-### Knative Serving updated to 0.8.1 
+### Knative Serving updated to 0.8.1
 
 We updated our bundled Knative Serving to [v0.8.1 release](https://github.com/knative/serving/releases/tag/v0.8.1). This is the first release candidate for Serving v1 and comes with many exciting features, such as Target Burst Capacity.
 
 
-## Service Management 
+## Service Management
 
 ### Service Catalog switched to new CRD implementation
 
 After a couple of months of hard work with development and integrations in the upstream Service Catalog project, we have finally removed Service Catalog API Server and ectd components from Kyma. Now, the Service Catalog design is based on the CRDs approach, which enhances the Service Catalog with the following:
 * The stability of the Service Catalog increased as now we use the native Kubernetes support instead of our own etcd cluster, which sometimes was unstable and caused downtimes.
-* The installation time was reduced almost by 65% (in average from 85sec to 30sec). 
+* The installation time was reduced almost by 65% (in average from 85sec to 30sec).
 * The memory consumption was reduced:
     - requested by 82% (from 232MB to 40MB)
     - limits by 96% (from 1596MB to 60MB)
@@ -163,7 +163,7 @@ After a couple of months of hard work with development and integrations in the u
     - requested by 43% (from 350m to 200m)
     - limits by 75% (from 800m to 200m)
 
-See [this](https://svc-cat.io/docs/design/#service-catalog-design) document for more information about the new Service Catalog design. What is more, in this release we provided a migration job that handles managed Service Catalog data upgrade between 1.5 and 1.6 Kyma versions. For more information, read [this](https://svc-cat.io/docs/migration-apiserver-to-crds/) document.
+See [this](https://svc-cat.io/docs/design/#service-catalog-design) document for more information about the new Service Catalog design. What is more, in this release we provided a migration job that handles managed Service Catalog data upgrade between 1.5 and 1.6 Kyma versions. For more information, read [this](https://svc-cat.io/docs/migration-apiserver-to-crds/) document, as well as the [migration guide](https://github.com/kyma-project/kyma/blob/release-1.6/docs/migration-guides/1.5-1.6.md).
 
 
 ### GCP Service Broker no longer in the preview mode
@@ -173,6 +173,6 @@ After some time spent in the preview mode, the GCP Service Broker joins other pr
 
 ## Service Mesh
 
-### Istio updated to 1.2.7 
+### Istio updated to 1.2.7
 
-The new release comes with Istio updated to 1.2.7 which provides fixes for the https://istio.io/news/2019/istio-security-2019-005/ security vulnerability. 
+The new release comes with Istio updated to 1.2.7 which provides fixes for the https://istio.io/news/2019/istio-security-2019-005/ security vulnerability.


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

We are adding the lacking migration guide to the 1.6 release branch, as many clients are having problems with migrating their Service Catalog data from 1.5 to 1.6. The migration guide must also be mentioned in the 1.6 release notes.

Changes proposed in this pull request:

- Add the reference to the migration guide to the 1.6 release notes

**Related issue(s)**
[#6210](https://github.com/kyma-project/kyma/pull/6210)