### PR TITLE
Remove broken links from release posts

### DIFF
--- a/content/blog-posts/2018-10-10-release-notes-0.4.1/index.md
+++ b/content/blog-posts/2018-10-10-release-notes-0.4.1/index.md
@@ -17,9 +17,9 @@ Now that we have our first official release, it is time to sum up what we have r
 
 ## Security
 
-In the area of security, we focused on our [API Gateway](/docs/0.4/components/api-gateway) that you can use to expose your API easily and in a secure way. We improved the following things:
+In the area of security, we focused on our [API Gateway](/docs/components/api-gateway) that you can use to expose your API easily and in a secure way. We improved the following things:
 * When you create the `Api` kind, `hostname` is validated to make sure you provided the correct domain and that there are no duplicates.
-* The [architecture](/docs/0.4/components/api-gateway#architecture-architecture) of the API Gateway component has changed. The services are now exposed by the Istio Gateway and the Istio Virtual Service, instead of the Istio Ingress.
+* The [architecture](/docs/components/api-gateway#architecture-architecture) of the API Gateway component has changed. The services are now exposed by the Istio Gateway and the Istio Virtual Service, instead of the Istio Ingress.
 * You can create several APIs for a single service in the Console UI by creating the API for a specific service in the **Services** view, or several different APIs from the **APIs** view.
 ![](./multi-api.png)
 
@@ -42,12 +42,12 @@ The Console UI is not everything, however. These are further changes:
 
 The Application Connector, that allows you to connect external systems with Kyma, underwent these major improvements:
 - Management of the Remote Environments (RE) is no longer done through the Helm chart. Instead, we have a controller that reacts to changes in the RE and sets up the whole Environment.
-- The [RemoteEnvironments CRD](/docs/0.4/components/application-connector#custom-resource-remoteenvironment) was enhanced with an extra label field. Now, you can mark the purpose of the Remote Environment in a flexible way.
+- The [RemoteEnvironments CRD](/docs/components/application-connector#custom-resource-remoteenvironment) was enhanced with an extra label field. Now, you can mark the purpose of the Remote Environment in a flexible way.
 - The OAuth token caching functionality was added to the Application Connector.
 
 ## Logging
 
-Kyma has a new component to enhance its logging capabilities. This component is based on [Logspout and OK Log](/docs/0.4/components/logging).
+Kyma has a new component to enhance its logging capabilities. This component is based on [Logspout and OK Log](/docs/components/logging).
 
 ## Monitoring
 
@@ -57,12 +57,12 @@ Through the proper Grafana configuration, all dashboards created by you in the r
 
 Our Kyma would not be so great without the support for the asynchronous communication between services. This is what we improved in that scope:
 - We enabled an Event lifecycle for storing Events in a cluster. By default, it is set to 24h, but you can configure the lifecycle in the NATS Streaming's StatefulSet by changing the `max_age` value.
-- We added the documentation for the service programming model for the Event subscribers. Read more [here](/docs/0.4/components/event-bus#details-service-programming-model).
+- We added the documentation for the service programming model for the Event subscribers. Read more [here](/docs/components/event-bus#details-service-programming-model).
 
 ## Tracing
 
 As you know, Kyma uses Jaeger as the tracing back-end. To improve its usage, we:
-- Secured the Jaeger UI so that you could access it easily without port-forwarding. Read more about [Jaeger](/docs/0.4/components/tracing#overview-overview).
+- Secured the Jaeger UI so that you could access it easily without port-forwarding. Read more about [Jaeger](/docs/components/tracing#overview-overview).
 - Created an example on how to enable tracing for an application. Read more [here](https://github.com/kyma-project/examples/tree/master/tracing).
 
 ## Service Mesh
@@ -74,11 +74,11 @@ At the moment, Kyma is using Istio [1.0.1](https://istio.io/about/notes/1.0.1/).
 The following improvements were done in the installation area:
 - The [Kyma installation on a Google Kubernetes Engine cluster](https://github.com/kyma-project/kyma/blob/0.5-rc/docs/kyma/docs/032-inst-gke-installation.md) is now possible mainly due to the implementation of the [API Server Proxy](https://github.com/kyma-project/kyma/tree/0.4.1/components/apiserver-proxy) component.
 - You can [override values in Helm charts](https://github.com/kyma-project/kyma/blob/0.5-rc/docs/kyma/docs/044-gs-installation-overrides.md) using config maps annotated with the `installer: overrides` label.
-- The extended [`Installation ` custom resource](/docs/0.4/root/kyma#custom-resource-installation) was enabled to allow you to provide a declarative list of modules that will be installed during the Kyma provisioning process.
+- The extended [`Installation ` custom resource](/docs/root/kyma#custom-resource-installation) was enabled to allow you to provide a declarative list of modules that will be installed during the Kyma provisioning process.
 
 ## Documentation
 
 A few weeks after the Kyma announcement, we published the official documentation on our `https://kyma-project.io/docs/` website. It is worth remembering, however, that this is not the only place where you can read the docs. Since the very beginning, the Kyma documentation has been an integral part of the Console UI, so whenever you provision a Kyma cluster, docs for a given Kyma version are always there for you. In the last few months we have improved the following features in that area:
-- The [Kyma overview](/docs/0.4/root/kyma#overview-overview) documentation and many other sections, like consistency of the [Custom Resource reference](/docs/0.4/components/service-catalog#custom-resource-custom-resource) documents.
+- The [Kyma overview](/docs/root/kyma#overview-overview) documentation and many other sections, like consistency of the [Custom Resource reference](/docs/components/service-catalog#custom-resource-custom-resource) documents.
 - The general feel and look of the documentation, its navigation, consistency, and the readability of the content.
 ![](./docs-ui.png)

--- a/content/blog-posts/2018-11-20-release-notes-0.5/index.md
+++ b/content/blog-posts/2018-11-20-release-notes-0.5/index.md
@@ -44,8 +44,8 @@ Authentication is enabled by default, and you can change JWKs URI using the **Lo
 We did a lot of great enhancements to the Kyma Service Catalog:
 
 - Support for &quot;namespaced&quot; service catalogs. This means a possibility to register brokers for specific Namespaces only. The Catalog has an additional Brokers view in the Environment context. The view lists Service Brokers registered only for a given Namespace.
-  - [Here](/docs/0.5/components/service-catalog#getting-started-getting-started) you can view a new getting started guide about brokers registration.
-  - [Here](/docs/0.5/components/service-catalog#architecture-architecture) you can find an architecture diagram for the Namespace catalog.
+  - [Here](/docs/components/service-catalog#getting-started-getting-started) you can view a new getting started guide about brokers registration.
+  - [Here](/docs/components/service-catalog#architecture-architecture) you can find an architecture diagram for the Namespace catalog.
   
   - The instance list and details views now work on web-sockets. This significantly improves the user experience because all changes to the instance, and most important its status, are updated in real-time in the view without the need for a page refresh. If you are interested in how we managed to accomplish that on a GraphQL layer with Istio and token verification, feel free to contact us on [Slack](http://slack.kyma-project.io).
 
@@ -67,7 +67,7 @@ We did a lot of great enhancements to the Kyma Service Catalog:
   
   - The UI supports the ServiceBinding creation if the owner of the service class specified a custom schema for binding creation.
   - The cleanup of resources got improved. When you decide to delete some Credentials, the related application bindings are also deleted.
-- [Helm Broker](/docs/0.5/components/service-brokers#configuration-configure-helm-broker) supports many bundle repositories.
+- [Helm Broker](/docs/components/service-brokers#configuration-configure-helm-broker) supports many bundle repositories.
 - The new [**bundles**](https://github.com/kyma-project/bundles) repository enables Kyma to install addons such as brokers, showcases and local services.
 
   - It contains bundles which the Helm Broker uses. It allows you to choose a set of bundles and configure the Helm Broker. You can also define your own bundles.
@@ -77,7 +77,7 @@ We did a lot of great enhancements to the Kyma Service Catalog:
 
 As eventing is one of the core principles Kyma is built on, we enhanced the functionality further:
 
-- It is now possible for developers to change their subscriptions and fix any typos or wrong configurations. It allows avoiding a situation where, for example, specifying a wrong URL causes wrong Event type to be updated. Click [here](/docs/0.5/components/event-bus#details-subscription-updates) to see how this can be done.
+- It is now possible for developers to change their subscriptions and fix any typos or wrong configurations. It allows avoiding a situation where, for example, specifying a wrong URL causes wrong Event type to be updated. Click [here](/docs/components/event-bus#details-subscription-updates) to see how this can be done.
 
 - A bug, which caused that it was impossible to create two subscriptions with same name in different Namespaces, has been fixed.
 - Kyma now enables a developer to understand better how to leverage tracing for handling problems in the Event flow.
@@ -107,16 +107,16 @@ After deleting the sub-validator Pod, Kubernetes recreates it automatically, and
 
 We constantly work on improving the security of Kyma:
 
-- Documentation is now available on how to [update TLS certificates](/docs/0.5/components/security#details-update-tls-certificate).
-- The static user password for administrators is generated during installation and stored in the secret admin-user in the `kyma-system` Namespace. You can add further static users by providing your own Kubernetes secrets. Use this [link](/docs/0.5/components/security#details-manage-static-users-in-dex) to learn more.
+- Documentation is now available on how to [update TLS certificates](/docs/components/security#details-update-tls-certificate).
+- The static user password for administrators is generated during installation and stored in the secret admin-user in the `kyma-system` Namespace. You can add further static users by providing your own Kubernetes secrets. Use this [link](/docs/components/security#details-manage-static-users-in-dex) to learn more.
 
 ## Service Mesh
 
-Istio is now installed from official Istio charts. Istio customization was externalized into a separate component: [istio-patch](/docs/0.5/components/service-mesh#details-istio-patch). As a result, Kyma can be installed on top of an existing [Istio installation](/docs/0.5/root/kyma#installation-installation-with-custom-istio-deployment) (in the supported version).
+Istio is now installed from official Istio charts. Istio customization was externalized into a separate component: [istio-patch](/docs/components/service-mesh#details-istio-patch). As a result, Kyma can be installed on top of an existing [Istio installation](/docs/root/kyma#installation-installation-with-custom-istio-deployment) (in the supported version).
 
 ## Installation
 
-The installation documentation was reorganized and grouped under [Installation](/docs/0.5/root/kyma#installation-installation).
+The installation documentation was reorganized and grouped under [Installation](/docs/root/kyma#installation-installation).
 
 ## Monitoring
 
@@ -143,11 +143,11 @@ Kyma was extended with Persistence Layer for logging based on OK Log.
 
 ## Tracing
 
-The Tracing UI is now linked from within the Kyma Console UI to make it easier to access the tracing information. Furthermore, it is now possible to compare two traces to track the process. You can get an answer to the question: &quot;Why did something unexpected happened?&quot; You can find more details [here](/docs/0.5/components/tracing#details-trace-comparison).
+The Tracing UI is now linked from within the Kyma Console UI to make it easier to access the tracing information. Furthermore, it is now possible to compare two traces to track the process. You can get an answer to the question: &quot;Why did something unexpected happened?&quot; You can find more details [here](/docs/components/tracing#details-trace-comparison).
 
 ## Console
 
-- You can extend the Console to add custom micro front-ends either for a single environment or for cluster-wide administration. More details can be found [here](/docs/0.5/components/console#details-ui-extensibility).
+- You can extend the Console to add custom micro front-ends either for a single environment or for cluster-wide administration. More details can be found [here](/docs/components/console#details-ui-extensibility).
 
 ![](./console_1.png) 
 

--- a/content/blog-posts/2019-01-14-release-notes-0.6/index.md
+++ b/content/blog-posts/2019-01-14-release-notes-0.6/index.md
@@ -67,7 +67,7 @@ To quickly switch the Console backend to work in the modular mode, run the follo
 kubectl set env deployment/core-ui-api MODULE_PLUGGABILITY=true -n kyma-system
 ```
 
-For more details about the introduced changes, read the related [documentation](/docs/0.6/components/console#details-ui-api-layer).
+For more details about the introduced changes, read the related [documentation](/docs/components/console#details-ui-api-layer).
 
 ### AsyncApi rendering  
 
@@ -122,13 +122,13 @@ You can now test Kyma on a cluster with a wildcard DNS provided by `xip.io`. 
 
 We introduced a new `xip-patch` job to Kyma as an optionally installed patch component. This patch issues a self-signed TLS certificate for the Kyma instance and configures the domain to `{LOADBALANCER_IP}.xip.io`, where `{LOADBALANCER_IP}` is the IP address of the assigned load balancer in the Kyma cluster. 
 
-This feature allows you to install and use Kyma easier, without owning a domain or issuing the TLS certificate on your own. This solution is not suitable for a production environment. It is only a playground you can use to get to know the product better. Read more about this optional feature [here](/docs/0.6/root/kyma#installation-install-kyma-on-a-gke-cluster-with-wildcard-dns).
+This feature allows you to install and use Kyma easier, without owning a domain or issuing the TLS certificate on your own. This solution is not suitable for a production environment. It is only a playground you can use to get to know the product better. Read more about this optional feature [here](/docs/root/kyma#installation-install-kyma-on-a-gke-cluster-with-wildcard-dns).
 
 ### Installation with Knative
 
 You can now install Kyma together with Knative and expose APIs using the `knative-ingressgateway` service. Knative installation also enables future work on integrating Kyma eventing with Knative eventing.
 
-Find out how to [install](/docs/0.6/root/kyma#installation-installation-with-knative) Kyma with Knative.
+Find out how to [install](/docs/root/kyma#installation-installation-with-knative) Kyma with Knative.
 
 
 ## Serverless
@@ -141,14 +141,14 @@ Kyma now uses Kubeless v1, the first stable release of Kubeless. 
 
 Lambda functions use the Kubernetes Horizontal Pod Autoscaler to scale the number of Pods based on CPU usage. To prevent any unexpected scaling, autoscaling was limited to the function type. We also created a frequently scheduled load test to validate the scaling behavior on Azure. 
 
-The Horizontal Pod Autoscaler is not enabled in your local Kyma installation by default, so you need to activate it manually. Read [this](/docs/0.6/root/kyma#installation-install-kyma-locally-from-the-release-enable-horizontal-pod-autoscaler-hpa-) document to learn how to do that.
+The Horizontal Pod Autoscaler is not enabled in your local Kyma installation by default, so you need to activate it manually. Read [this](/docs/root/kyma#installation-install-kyma-locally-from-the-release-enable-horizontal-pod-autoscaler-hpa-) document to learn how to do that.
 
 
 ## Service Catalog
 
 ### Google Cloud Platform Service Broker
 
-Kyma provides the Google Cloud Platform (GCP) Service Broker. Apart from the GCP standard integration offering, you can configure the GCP Broker for a specific GCP project in a given Kyma Namespace. Install the GCP Service Broker by provisioning the **Google Cloud Platform Service Broker Provider** class exposed by the Helm Broker. Read more about this new feature [here](/docs/0.6/components/service-brokers#overview-google-cloud-platform-broker).
+Kyma provides the Google Cloud Platform (GCP) Service Broker. Apart from the GCP standard integration offering, you can configure the GCP Broker for a specific GCP project in a given Kyma Namespace. Install the GCP Service Broker by provisioning the **Google Cloud Platform Service Broker Provider** class exposed by the Helm Broker. Read more about this new feature [here](/docs/components/service-brokers#overview-google-cloud-platform-broker).
 
 ![](./gcp-provider-class.png)
 
@@ -156,7 +156,7 @@ Kyma provides the Google Cloud Platform (GCP) Service Broker. Apart from the GCP
 
 We split the Kyma Service Catalog module into `service-catalog` and `service-catalog-addons`. The `service-catalog` module contains the core functionality and can be excluded from the Kyma installation if the Service Catalog is already installed on the cluster. The `service-catalog-addons` module contains all features built around the core, such as automatic bindings and the UI.
 
-Follow [these](/docs/0.6/root/kyma#installation-installation-with-custom-service-catalog-deployment) steps to install Kyma with a custom Service Catalog deployment.
+Follow [these](/docs/root/kyma#installation-installation-with-custom-service-catalog-deployment) steps to install Kyma with a custom Service Catalog deployment.
 
 ### New tooling for the Service Catalog UI tests
 

--- a/content/blog-posts/2019-02-14-release-notes-0.7/index.md
+++ b/content/blog-posts/2019-02-14-release-notes-0.7/index.md
@@ -50,11 +50,11 @@ We have increased the default memory limit for the Application Registry payload 
 
 ### API secured with client certificates
 
-Application Proxy allows you to secure APIs with generated client certificates. When you register an API with a client certificate, the Application Registry generates a ready-to-use certificate and key pair for this API to secure it. You can use the generated pair or replace it with your own certificate and key. For details, see [this](/docs/0.7/components/application-connector#tutorials-register-a-secured-api) document.
+Application Proxy allows you to secure APIs with generated client certificates. When you register an API with a client certificate, the Application Registry generates a ready-to-use certificate and key pair for this API to secure it. You can use the generated pair or replace it with your own certificate and key. For details, see [this](/docs/components/application-connector#tutorials-register-a-secured-api) document.
 
 ### Known issues
 
-If you run Kyma on Minikube, you must expose the Nginx Ingress Controller on the dedicated NodePort. However, URLs returned from the Connector Service do not include the value for this port. To fix it, update URLs manually using the information in [this](/docs/0.7/components/application-connector#api-application-registry) guide.
+If you run Kyma on Minikube, you must expose the Nginx Ingress Controller on the dedicated NodePort. However, URLs returned from the Connector Service do not include the value for this port. To fix it, update URLs manually using the information in [this](/docs/components/application-connector#api-application-registry) guide.
 
 ## Asset Store
 
@@ -70,7 +70,7 @@ This version of the Asset Store brings you the following features included in th
 * Providing custom mutation services for assets to modify them before uploading them to the storage.
 
 
-In the coming releases, we plan to address the remaining features from the proposal. If you are interested in contributing, feel free to contact us on [Slack](http://slack.kyma-project.io). Meanwhile, read [this](/docs/0.7/components/asset-store#overview-overview) document to find out more about the Asset Store component.
+In the coming releases, we plan to address the remaining features from the proposal. If you are interested in contributing, feel free to contact us on [Slack](http://slack.kyma-project.io). Meanwhile, read [this](/docs/components/asset-store#overview-overview) document to find out more about the Asset Store component.
 
 ### Known issues
 
@@ -118,7 +118,7 @@ You can now deploy Kyma using Kubernetes v1.11.5, to enjoy improved stability an
 
 ### Kyma on AKS
 
-You can now smoothly deploy Kyma on an AKS cluster, using a chosen release version or even a particular commit. [Install](/docs/0.7/root/kyma#installation-install-kyma-on-an-aks-cluster) Kyma on a cluster using a proprietary installer based on a Kubernetes operator. If you want to try out Kyma on a cluster without assigning the cluster to a domain you own, you can use `xip.io` which provides a wildcard DNS for any IP address. For details, see [this guide](/docs/0.7/root/kyma#installation-install-kyma-on-an-aks-cluster-with-wildcard-dns).
+You can now smoothly deploy Kyma on an AKS cluster, using a chosen release version or even a particular commit. [Install](/docs/root/kyma#installation-install-kyma-on-an-aks-cluster) Kyma on a cluster using a proprietary installer based on a Kubernetes operator. If you want to try out Kyma on a cluster without assigning the cluster to a domain you own, you can use `xip.io` which provides a wildcard DNS for any IP address. For details, see [this guide](/docs/root/kyma#installation-install-kyma-on-an-aks-cluster-with-wildcard-dns).
 
 
 ### kyma-default ResourceQuota removed  
@@ -139,17 +139,17 @@ The Prometheus Operator module used to be required in any Kyma setup. To increas
 
 ###  UI API Layer security model
 
-We have switched from a custom Istio RBAC implementation based on Envoy to Kubernetes RBAC. The reason was to avoid difficulties of developing and maintaining the LUA filters for Envoy. Additionally, the current implementation uses Go, which makes it more lightweight and flexible. Read the [documentation](/docs/0.7/components/security#details-graphql) to learn the details on securing resources in GraphQL using queries, mutations, and subscriptions.
+We have switched from a custom Istio RBAC implementation based on Envoy to Kubernetes RBAC. The reason was to avoid difficulties of developing and maintaining the LUA filters for Envoy. Additionally, the current implementation uses Go, which makes it more lightweight and flexible. Read the [documentation](/docs/components/security#details-graphql) to learn the details on securing resources in GraphQL using queries, mutations, and subscriptions.
 
 ## Service Catalog
 
 ### Azure Service Broker runtime bundling and installation
 
-Kyma allows you to integrate with the Azure Service Broker in an easy way, and to use the vast range of Service Classes it provides. Each Service Class is comprehensively described in the [documentation](https://github.com/kyma-project/addons/tree/master/addons/azure-service-broker-0.0.1/docs). Read more about the Azure Service Broker [here](https://kyma-project.io/docs/0.7/components/helm-broker/#overview-azure-broker).
+Kyma allows you to integrate with the Azure Service Broker in an easy way, and to use the vast range of Service Classes it provides. Each Service Class is comprehensively described in the [documentation](https://github.com/kyma-project/addons/tree/master/addons/azure-service-broker-0.0.1/docs). Read more about the Azure Service Broker [here](https://kyma-project.io/docs/components/helm-broker/#overview-azure-broker).
 
 ### One-time provisioning for Helm Broker
 
-The Helm Broker now supports the `provisionOnlyOnce` flag which defines that the bundle should be provisioned only once for a given Namespace. We have also added this flag to the Azure Service Broker and the GCP Service Broker bundle configurations. For details, read [this](/docs/0.7/components/helm-broker#configuration-binding-bundles) document.
+The Helm Broker now supports the `provisionOnlyOnce` flag which defines that the bundle should be provisioned only once for a given Namespace. We have also added this flag to the Azure Service Broker and the GCP Service Broker bundle configurations. For details, read [this](/docs/components/helm-broker#configuration-binding-bundles) document.
 
 ## Service Catalog standalone installation
 

--- a/content/blog-posts/2019-03-14-release-notes-0.8/index.md
+++ b/content/blog-posts/2019-03-14-release-notes-0.8/index.md
@@ -48,7 +48,7 @@ The new `GetInfo` endpoint returns information about the cluster. Use it to get 
 
 ### Certificate management
 
-We added new functionalities centered around certificate management, such as signing certificates for Applications and Kyma clusters, [renewing certificates](/docs/0.8/components/application-connector/#tutorials-renew-the-client-certificate), and [certificate revocation](/docs/0.8/components/application-connector/#tutorials-revoke-the-client-certificate).
+We added new functionalities centered around certificate management, such as signing certificates for Applications and Kyma clusters, [renewing certificates](/docs/components/application-connector/#tutorials-renew-the-client-certificate), and [certificate revocation](/docs/components/application-connector/#tutorials-revoke-the-client-certificate).
 
 ### Proxy Service renaming
 
@@ -63,7 +63,7 @@ If you upgrade Kyma 0.7 to version 0.8, you must manually update the IP address 
 
 ### New cluster-wide resources added
 
-We added two new cluster-wide resources, ClusterAsset and ClusterBucket. These resources allow you to fully use the Asset Store and build solutions using it. Read [this document](/docs/0.8/components/asset-store/#custom-resource-clusterasset) for more information.
+We added two new cluster-wide resources, ClusterAsset and ClusterBucket. These resources allow you to fully use the Asset Store and build solutions using it. Read [this document](/docs/components/asset-store/#custom-resource-clusterasset) for more information.
 
 ### Package filtering
 
@@ -71,7 +71,7 @@ Assets now allow you to specify which folders should the Asset Store process usi
 
 ### Upload service
 
-The newly introduced upload service enables easy integration for components that dynamically create and publish packages. By default, the service is configured to be accessible only from within the cluster. You can use the Upload Service to temporarily publish files that need to be referenced in assets. For details, read [this](/docs/0.8/components/asset-store#details-asset-upload-service ) document.
+The newly introduced upload service enables easy integration for components that dynamically create and publish packages. By default, the service is configured to be accessible only from within the cluster. You can use the Upload Service to temporarily publish files that need to be referenced in assets. For details, read [this](/docs/components/asset-store#details-asset-upload-service ) document.
 
 ### Minio monitoring
 
@@ -82,7 +82,7 @@ The Asset Store uses Minio as its backend, with a standalone setup on local depl
 
 ### Backup and restore feature added
 
-We implemented an [Ark](https://github.com/heptio/velero/)-based backup functionality in Kyma, allowing you to create manual and scheduled backups. Read our [documentation](/docs/0.8/components/backup/) to learn how to configure backups, restore your cluster from backup, and set backup retention period.
+We implemented an [Ark](https://github.com/heptio/velero/)-based backup functionality in Kyma, allowing you to create manual and scheduled backups. Read our [documentation](/docs/components/backup/) to learn how to configure backups, restore your cluster from backup, and set backup retention period.
 
 ### E2E tests for backup and restore
 
@@ -90,7 +90,7 @@ We added a new pipeline to Prow which allows testing the backup and restore feat
 
 ### Known issues
 
-Currently, the backup and restore feature doesn't cover all components. As a workaround, add the outstanding components to Ark configuration manually as described in the [documentation](/docs/0.8/components/backup/#details-back-up-a-kyma-cluster).
+Currently, the backup and restore feature doesn't cover all components. As a workaround, add the outstanding components to Ark configuration manually as described in the [documentation](/docs/components/backup/#details-back-up-a-kyma-cluster).
 
 
 ## Console
@@ -160,7 +160,7 @@ In this release, we replaced OK Log with a new logging solution - Loki. Dubbed t
 
 ### Kyma-developer role
 
-We introduced a new cluster-wide role suited for developers working with Kyma. The **kyma-developer** role has fewer privileges than the existing **kyma-admin** role but allows for more access than the existing, Namespace-specific **kyma-reader** role. Assign the new role to any developer that develop solutions in your cluster. Read [this](/docs/0.8/components/security/#tutorials-manage-static-users-in-dex-bind-a-user-to-a-role-or-a-clusterrole) document for more information.
+We introduced a new cluster-wide role suited for developers working with Kyma. The **kyma-developer** role has fewer privileges than the existing **kyma-admin** role but allows for more access than the existing, Namespace-specific **kyma-reader** role. Assign the new role to any developer that develop solutions in your cluster. Read [this](/docs/components/security/#tutorials-manage-static-users-in-dex-bind-a-user-to-a-role-or-a-clusterrole) document for more information.
 
 ### Shorter ID token TTL
 
@@ -182,7 +182,7 @@ Functions are logging their source code and `package.json` content before they a
 
 ### Define the URLs of the repositories that hold your bundles in the Helm Broker
 
-You can now instantly update the URLs of your bundles repositories in the Helm Broker, with no need to restart. For more information, read [this](/docs/0.8/components/helm-broker#configuration-configure-helm-broker-add-a-new-bundle-repository) document.
+You can now instantly update the URLs of your bundles repositories in the Helm Broker, with no need to restart. For more information, read [this](/docs/components/helm-broker#configuration-configure-helm-broker-add-a-new-bundle-repository) document.
 
 
 ## kyma-project.io

--- a/content/blog-posts/2019-04-08-release-notes-0.9/index.md
+++ b/content/blog-posts/2019-04-08-release-notes-0.9/index.md
@@ -42,15 +42,15 @@ See the overview of all changes in this release:
 
 ### Application Registry API can fetch generated client certificates
 
-We extended the Application Registry API with the possibility to fetch the generated client certificates. As soon as you register an API secured with the client certificate verification as a security mechanism, you can read this certificate with our API. Read [this](https://kyma-project.io/docs/0.9/components/application-connector/#tutorials-register-a-secured-api) document for more information.
+We extended the Application Registry API with the possibility to fetch the generated client certificates. As soon as you register an API secured with the client certificate verification as a security mechanism, you can read this certificate with our API. Read [this](/docs/components/application-connector/#tutorials-register-a-secured-api) document for more information.
 
 ### Apply details for the tenant and group name
 
-We extended the TokenRequest functionality and now you can apply details for the tenant name and group name. It allows you to easily manage the token generation process for pairing applications in the central Connector Service. For more details, read [this](https://kyma-project.io/docs/0.9/components/application-connector#custom-resource-token-request) document.
+We extended the TokenRequest functionality and now you can apply details for the tenant name and group name. It allows you to easily manage the token generation process for pairing applications in the central Connector Service. For more details, read [this](/docs/components/application-connector#custom-resource-token-request) document.
 
 ### Read about the Root CA rotation procedure
 
-We updated our documentation with the description of the [Root CA rotation procedure](https://kyma-project.io/docs/0.9/components/application-connector/#tutorials-rotate-the-root-ca-certificate-and-key).
+We updated our documentation with the description of the [Root CA rotation procedure](/docs/components/application-connector/#tutorials-rotate-the-root-ca-certificate-and-key).
 
 ### Acceptance tests for the Gateway Service
 
@@ -58,7 +58,7 @@ We enhanced the Gateway Service with the extended set of acceptance tests, which
 
 ### Headers management
 
-We changed the Application Gateway proxy functionality and now the unnecessary headers, such as `X-Forwarded-For`, are removed while making calls to external solutions. For the full list of removed headers, read [this](https://kyma-project.io/docs/0.9/components/application-connector/#architecture-application-gateway-handling-of-headers) document.
+We changed the Application Gateway proxy functionality and now the unnecessary headers, such as `X-Forwarded-For`, are removed while making calls to external solutions. For the full list of removed headers, read [this](/docs/components/application-connector/#architecture-application-gateway-handling-of-headers) document.
 
 
 ## Console
@@ -122,9 +122,9 @@ spec:
 
 ### Headless CMS
 
-In Kyma, we value the content-as-code principle. It means that documentation is treated the same as code, as in the end, it is not much different. We decided to go one step further. If content is like code, why not deploy it into the Kubernetes cluster as code as well? If you can easily deploy a service using the Deployment resource, you can do the same with documentation. This is what we implemented - the Headless CMS, based on Kubernetes Custom Resource Definitions, that uses our other component, the [Asset Store](https://kyma-project.io/docs/0.9/components/asset-store), for storage.
+In Kyma, we value the content-as-code principle. It means that documentation is treated the same as code, as in the end, it is not much different. We decided to go one step further. If content is like code, why not deploy it into the Kubernetes cluster as code as well? If you can easily deploy a service using the Deployment resource, you can do the same with documentation. This is what we implemented - the Headless CMS, based on Kubernetes Custom Resource Definitions, that uses our other component, the [Asset Store](/docs/components/asset-store), for storage.
 
-The Headless CMS itself does not yet deliver any customizable UI interface that could be used to publish a standalone documentation portal. Nevertheless, we already use it in the Console UI. For more details, read the Headless CMS [documentation](https://kyma-project.io/docs/0.9/components/headless-cms).
+The Headless CMS itself does not yet deliver any customizable UI interface that could be used to publish a standalone documentation portal. Nevertheless, we already use it in the Console UI. For more details, read the Headless CMS [documentation](/docs/components/headless-cms).
 
 ### Asset Store supports a webhook service that can enhance the status of the CR with additional metadata for each file
 
@@ -153,11 +153,11 @@ spec:
       filter: \.md$
 ```
 
-To learn more about webhook services, read [this](https://kyma-project.io/docs/0.9/components/asset-store/#custom-resource-asset-validation-and-mutation-webhook-services) document.
+To learn more about webhook services, read [this](/docs/components/asset-store/#custom-resource-asset-validation-and-mutation-webhook-services) document.
 
 ### Asset Store stack enhanced with a default service that can extract metadata from any file
 
-With the support of the new metadata webhook, we added a default service to the Asset Store domain. You can use it to extract the front matter metadata provided in any file of the `yaml` format. We already use this service in the Headless CMS component. For more details, read [this](https://kyma-project.io/docs/0.9/components/asset-store/#details-asset-metadata-service) document.
+With the support of the new metadata webhook, we added a default service to the Asset Store domain. You can use it to extract the front matter metadata provided in any file of the `yaml` format. We already use this service in the Headless CMS component. For more details, read [this](/docs/components/asset-store/#details-asset-metadata-service) document.
 
 
 ## Eventing
@@ -201,7 +201,7 @@ From this release, communication with Tiller requires a TLS certificate. For dev
 
 ### Helm Broker enforces TLS for external bundles repositories
 
-From now on, on your non-local clusters, you can use only servers with TLS enabled. All incorrect or unsecured URLs will be omitted. You can use unsecured URLs only on your local cluster. For more information, read [this](https://kyma-project.io/docs/0.9/components/helm-broker/#configuration-configuration-configuration-rules) document.
+From now on, on your non-local clusters, you can use only servers with TLS enabled. All incorrect or unsecured URLs will be omitted. You can use unsecured URLs only on your local cluster. For more information, read [this](/docs/components/helm-broker/#configuration-configuration-configuration-rules) document.
 
 ### Istio with mutual TLS for the Service Catalog and Service Brokers
 

--- a/content/blog-posts/2019-05-17-release-notes-1.1/index.md
+++ b/content/blog-posts/2019-05-17-release-notes-1.1/index.md
@@ -43,11 +43,11 @@ In this release, we optimized the memory consumption for the Application Operato
 
 ### OData support in documentation
 
-You can now read the updated Application Connector documentation that includes information on the supported APIs, including the support for [OData API registration](/docs/1.1/components/application-connector/#overview-overview-supported-apis).
+You can now read the updated Application Connector documentation that includes information on the supported APIs, including the support for [OData API registration](/docs/components/application-connector/#overview-overview-supported-apis).
 
 ### New Event Service endpoint
 
-We enriched the Event Service with the new `/{application}/v1/events/subscribed` endpoint that only returns information on the subscribed Events. This endpoint is perfect for your system optimization as the connected application no longer needs to send Events that are not used by any lambda or service. [Read more](/docs/1.1/components/application-connector/#api-event-service) about the endpoint and learn how you can use it to fetch Events.
+We enriched the Event Service with the new `/{application}/v1/events/subscribed` endpoint that only returns information on the subscribed Events. This endpoint is perfect for your system optimization as the connected application no longer needs to send Events that are not used by any lambda or service. [Read more](/docs/components/application-connector/#api-event-service) about the endpoint and learn how you can use it to fetch Events.
 
 
 ## Console
@@ -67,12 +67,12 @@ We added the `SYSTEM` badge to the system Namespaces. Thanks to it, you can easi
 
 ### Minio Gateway mode
 
-The [Asset Store](/docs/1.1/components/asset-store) that ensures asset management in Kyma uses [Minio](https://min.io/) as a back-end solution. As stated in our documentation, we recommend that you use Minio in its Gateway mode for your production environment. This means you should use Minio as a gateway to Google Cloud Storage (GCS).
+The [Asset Store](/docs/components/asset-store) that ensures asset management in Kyma uses [Minio](https://min.io/) as a back-end solution. As stated in our documentation, we recommend that you use Minio in its Gateway mode for your production environment. This means you should use Minio as a gateway to Google Cloud Storage (GCS).
 
 In this release, we focused on preparing an easy switch from the standalone mode to the Gateway mode by:
 - Making sure your data is seamlessly recreated after the switch.
 - Improving the stability of the Asset Store with Minio in the Gateway mode.
-- Providing clear documentation on how to [switch to GCS](/docs/1.1/components/asset-store/#tutorials-set-minio-to-the-google-cloud-storage-gateway-mode).
+- Providing clear documentation on how to [switch to GCS](/docs/components/asset-store/#tutorials-set-minio-to-the-google-cloud-storage-gateway-mode).
 - Integrating the Minio Gateway mode with our testing pipeline. This way, we can now test any new functionality against the Minio Gateway mode pointing to GCS.
 
 
@@ -83,14 +83,14 @@ In this release, we focused on preparing an easy switch from the standalone mode
 In 1.1, we focused on creating configuration documents and simplifying the existing installation documents.
 
 Configuration improvements:
-- An [overview](/docs/1.1/root/kyma/#configuration-overview) document explaining what you can configure in Kyma and how you can do it before and after installation
-- Improved documents on selected [component installation](/docs/1.1/root/kyma/#configuration-custom-component-installation) and chart values [overrides](/docs/1.1/root/kyma/#configuration-helm-overrides-for-kyma-installation)
+- An [overview](/docs/root/kyma/#configuration-overview) document explaining what you can configure in Kyma and how you can do it before and after installation
+- Improved documents on selected [component installation](/docs/root/kyma/#configuration-custom-component-installation) and chart values [overrides](/docs/root/kyma/#configuration-helm-overrides-for-kyma-installation)
 - A [template](https://github.com/kyma-project/community/blob/master/guidelines/templates/resources/configuration.md) for the **Configuration** document type that provides technical details about configuration of a Kyma component's chart or sub-chart
-- A set of configuration documents for the [Asset Store](/docs/1.1/components/asset-store/#configuration-configuration) specifying the configurable parameters from the `values.yaml` charts and sub-charts that you can override. You can expect more of such documents for other Kyma components to come in the upcoming releases
+- A set of configuration documents for the [Asset Store](/docs/components/asset-store/#configuration-configuration) specifying the configurable parameters from the `values.yaml` charts and sub-charts that you can override. You can expect more of such documents for other Kyma components to come in the upcoming releases
 
 Installation improvements:
-- A simplified [cluster installation](/docs/1.1/root/kyma/#installation-install-kyma-on-a-cluster) document explaining how you can quickly deploy Kyma on a cluster with a wildcard DNS provided by `xip.io`
-- A unified [local installation](/docs/1.1/root/kyma/#installation-install-kyma-locally) flow
+- A simplified [cluster installation](/docs/root/kyma/#installation-install-kyma-on-a-cluster) document explaining how you can quickly deploy Kyma on a cluster with a wildcard DNS provided by `xip.io`
+- A unified [local installation](/docs/root/kyma/#installation-install-kyma-locally) flow
 
 
 ## Eventing
@@ -116,7 +116,7 @@ There are two new dashboards available in Grafana:
 ### Octopus in Kyma
 
 As part of productivity improvements in Kyma, we replaced Helm tests with the Octopus test runner. Kyma components now use Octopus as a testing framework to run tests defined as Docker images on a running cluster.
-Read more about [testing](/docs/1.1/root/kyma/#details-testing-kyma) in Kyma, [Octopus](https://github.com/kyma-incubator/octopus/blob/master/README.md) itself, and the benefits it brings to the Kyma testing process.
+Read more about [testing](/docs/root/kyma/#details-testing-kyma) in Kyma, [Octopus](https://github.com/kyma-incubator/octopus/blob/master/README.md) itself, and the benefits it brings to the Kyma testing process.
 
 
 ## Service Management
@@ -131,11 +131,11 @@ Aiming to improve your user experience, we split the Catalog UI view into **Add-
 
 ### AWS Service Broker add-on
 
-As part of our constant efforts to improve your experience on third-party Service Brokers in Kyma, we extended our Service Catalog with Amazon offerings. The new [AWS Service Broker](/docs/1.1/components/service-catalog/#service-brokers-aws-service-broker) is available for you as an add-on, extending the existing GCP and Azure Service Brokers add-on family.
+As part of our constant efforts to improve your experience on third-party Service Brokers in Kyma, we extended our Service Catalog with Amazon offerings. The new [AWS Service Broker](/docs/components/service-catalog/#service-brokers-aws-service-broker) is available for you as an add-on, extending the existing GCP and Azure Service Brokers add-on family.
 
 ### Documentation support for add-ons
 
-The Helm Broker creates Service Class documentation from an add-on which appears in the **Add-Ons** Catalog UI view. [Read](https://kyma-project.io/docs/1.1/components/helm-broker#details-create-a-bundle-docs-directory) how to add documentation to your add-on. If your add-on extends the Service Catalog UI, [read](/docs/1.1/components/helm-broker#details-service-classes-documentation-provided-by-bundles) how to provide documentation for those new Service Classes.
+The Helm Broker creates Service Class documentation from an add-on which appears in the **Add-Ons** Catalog UI view. [Read](/docs/components/helm-broker#details-create-a-bundle-docs-directory) how to add documentation to your add-on. If your add-on extends the Service Catalog UI, [read](/docs/components/helm-broker#details-service-classes-documentation-provided-by-bundles) how to provide documentation for those new Service Classes.
 
 ### "Provision only once" APIs and Events
 

--- a/content/blog-posts/2019-06-13-release-notes-1.2/index.md
+++ b/content/blog-posts/2019-06-13-release-notes-1.2/index.md
@@ -44,13 +44,13 @@ Read about a known issue for [Observability](#known-issues).
 
 From the very beginning of the Kyma project, the Application Connector has been exposed using the NGINX Ingress. After the recent changes in Istio 1.x which included support for client certificates, we decided to migrate to Istio as did the rest of Kyma components. We are proud to announce that the migration is complete and we are already benefiting from a number of advantages including easier maintenance and a smaller number of components in the implementation.
 
-Read [this](/docs/1.2/components/application-connector/#architecture-architecture) document to learn more about the role Istio plays in the Application Connector.
+Read [this](/docs/components/application-connector/#architecture-architecture) document to learn more about the role Istio plays in the Application Connector.
 
 ### Custom headers and query parameters in authentication requests
 
 To facilitate the integration of APIs that require sending additional headers and query parameters with every request to an external system, we allow the developers to provide a custom list of the headers and query parameters when registering an API in the Application Registry. The Proxy service reads this configuration and enriches each call from an API to an external service with the required items.
 
-Read [this](/docs/1.2/components/application-connector/#tutorials-register-a-secured-api-specify-custom-headers-and-query-parameters-for-authentication-requests) document to learn more.
+Read [this](/docs/components/application-connector/#tutorials-register-a-secured-api-specify-custom-headers-and-query-parameters-for-authentication-requests) document to learn more.
 
 ## Console
 
@@ -66,17 +66,17 @@ Users can now configure more of the important Namespace options when they create
 
 ### Kyma available on GCP Marketplace
 
-Deploying on GKE is now easier than ever as you can get a fully functional Kyma deployment with `http://xip.io/` straight from the GCP Marketplace. Follow [this link](https://console.cloud.google.com/marketplace/details/sap-public/kyma) to find Kyma on the Marketplace, read [this](/docs/1.2/root/kyma/#installation-install-kyma-on-a-cluster) document to get detailed installation instructions, and watch [this video](https://www.youtube.com/watch?v=hxVhQqI1B5A) for a detailed walkthrough. Enjoy!
+Deploying on GKE is now easier than ever as you can get a fully functional Kyma deployment with `http://xip.io/` straight from the GCP Marketplace. Follow [this link](https://console.cloud.google.com/marketplace/details/sap-public/kyma) to find Kyma on the Marketplace, read [this](/docs/root/kyma/#installation-install-kyma-on-a-cluster) document to get detailed installation instructions, and watch [this video](https://www.youtube.com/watch?v=hxVhQqI1B5A) for a detailed walkthrough. Enjoy!
 
 ### Platform-agnostic local deployments with Kyma CLI
 
 Our very own [Kyma CLI](https://github.com/kyma-project/cli) graduated from the Incubator and became an integral part of Kyma with the 1.2 release. From now on you can use simple `kyma` commands to easily deploy Kyma on your local machine, no matter what OS you're running - all you have to do is install our proprietary CLI tool. The local installation flow is now updated to use the CLI and we are retiring the old installation approach that used custom scripts.
 
-To experience the convenience the Kyma CLI brings to the table, follow [our documentation](/docs/1.2/root/kyma/#installation-install-kyma-locally) to install Kyma on your machine.
+To experience the convenience the Kyma CLI brings to the table, follow [our documentation](/docs/root/kyma/#installation-install-kyma-locally) to install Kyma on your machine.
 
 ### Simpler cluster installation
 
-The existing cluster installation flows were significantly simplified. The `sed` commands and the cluster configuration template file are now gone in favor of a set of `kubectl` calls. Now you simply set up your cluster, apply the desired configuration with `kubectl`, and wait for the magic to happen. For more details, see the [installation documentation](/docs/1.2/root/kyma/#installation-installation).
+The existing cluster installation flows were significantly simplified. The `sed` commands and the cluster configuration template file are now gone in favor of a set of `kubectl` calls. Now you simply set up your cluster, apply the desired configuration with `kubectl`, and wait for the magic to happen. For more details, see the [installation documentation](/docs/root/kyma/#installation-installation).
 
 ## Documentation
 
@@ -86,15 +86,15 @@ After preparing a set of generic configuration documents in the last release, th
 
 ### Troubleshooting guides
 
-As we interact with the community, we take note of recurring issues and misunderstandings that affect different components. We decide to gather these cases under the **Troubleshooting** documentation type to help the users deal with the most common issues easily. The troubleshooting documents are now available for the [Service Mesh](/docs/1.2/components/service-mesh/#troubleshooting-troubleshooting) and the general [Kyma](/docs/1.2/root/kyma/#troubleshooting-troubleshooting-overview) topic.
+As we interact with the community, we take note of recurring issues and misunderstandings that affect different components. We decide to gather these cases under the **Troubleshooting** documentation type to help the users deal with the most common issues easily. The troubleshooting documents are now available for the [Service Mesh](/docs/components/service-mesh/#troubleshooting-troubleshooting) and the general [Kyma](/docs/root/kyma/#troubleshooting-troubleshooting-overview) topic.
 
 ### Markdown documents in Headless CMS
 
-If you've ever had any doubts regarding what the structure of a Markdown document processed by Headless CMS should look like, we come with a solution. See the [document](/docs/1.2/components/headless-cms/#details-markdown-documents) describing the required metadata and content of a Markdown file.
+If you've ever had any doubts regarding what the structure of a Markdown document processed by Headless CMS should look like, we come with a solution. See the [document](/docs/components/headless-cms/#details-markdown-documents) describing the required metadata and content of a Markdown file.
 
 ### How to modify the Documentation view in the Console UI
 
-We prepared a tutorial that shows how to adjust the Documentation view in the Console UI. Based on it, you create a new Prometheus documentation section that contains Concepts and Guides topics and a set of Markdown subdocuments. [Try it](/docs/1.2/components/headless-cms/#tutorial-add-new-documents-to-the-documentation-view-in-the-console-ui) on your own.
+We prepared a tutorial that shows how to adjust the Documentation view in the Console UI. Based on it, you create a new Prometheus documentation section that contains Concepts and Guides topics and a set of Markdown subdocuments. [Try it](/docs/components/headless-cms/#tutorial-add-new-documents-to-the-documentation-view-in-the-console-ui) on your own.
 
 ### Testing bundle with sample documentation
 

--- a/content/blog-posts/2019-07-12-release-notes-1.3/index.md
+++ b/content/blog-posts/2019-07-12-release-notes-1.3/index.md
@@ -34,11 +34,11 @@ See the overview of all changes in this release:
 
 ### Fetching API specification secured with Basic Auth or OAuth
 
-Application Connector supports a variety of authentication methods to allow users to register secured APIs. Now you can also register APIs with a specification URL that requires authentication as the Application Connector can use credentials to fetch the API specification. The supported authentication methods for fetching API specifications are Basic Auth and OAuth. Read [this](https://kyma-project.io/docs/1.3/components/application-connector/#tutorials-register-a-service) document to learn more.   
+Application Connector supports a variety of authentication methods to allow users to register secured APIs. Now you can also register APIs with a specification URL that requires authentication as the Application Connector can use credentials to fetch the API specification. The supported authentication methods for fetching API specifications are Basic Auth and OAuth. Read [this](/docs/components/application-connector/#tutorials-register-a-service) document to learn more.   
 
 ### Automatic generation of the root Certificate Authority (CA)
 
-Application Connector serves as a certificate authority that issues client certificates for external systems. Users can provide their own certificates and keys to be used as the root CA. In order to improve security and reduce configuration effort, we automated the certificate and key generation process. From now on, if the user doesn't provide a custom certificate-key pair, the certificate and key are generated automatically. Read [this](https://kyma-project.io/docs/1.3/components/application-connector/#details-application-connector-certificates) document for more information. To learn how the automated certificate generation affects the upgrade process and how to preserve your certificate and key, read the [migration guide](https://github.com/kyma-project/kyma/blob/release-1.3/docs/migration-guides/1.2-1.3.md).
+Application Connector serves as a certificate authority that issues client certificates for external systems. Users can provide their own certificates and keys to be used as the root CA. In order to improve security and reduce configuration effort, we automated the certificate and key generation process. From now on, if the user doesn't provide a custom certificate-key pair, the certificate and key are generated automatically. Read [this](/docs/components/application-connector/#details-application-connector-certificates) document for more information. To learn how the automated certificate generation affects the upgrade process and how to preserve your certificate and key, read the [migration guide](https://github.com/kyma-project/kyma/blob/release-1.3/docs/migration-guides/1.2-1.3.md).
 
 ### Additional headers and query parameters stored in a secured way
 
@@ -61,7 +61,7 @@ The list of APIs contains up-to-date data with no need of refreshing the page. A
 
 ### Hide irrelevant navigation nodes
 
-In case you find some navigation nodes in the Console irrelevant, you can simply ignore them by defining a list of specific navigation nodes or even whole categories that should not show up in the Console UI navigation. Read [this](https://kyma-project.io/docs/1.3/components/console/#configuration-console-chart) document to learn more.
+In case you find some navigation nodes in the Console irrelevant, you can simply ignore them by defining a list of specific navigation nodes or even whole categories that should not show up in the Console UI navigation. Read [this](/docs/components/console/#configuration-console-chart) document to learn more.
 
 ### DevX improvements for the Lambda view
 
@@ -92,9 +92,9 @@ Our next step is to officially release this component and use it in other Kyma C
 
 ### Service Catalog migration from "API Server" to "CRD only"
 
-Now you can configure Kyma to use the experimental "CRD only" mode of our Service Catalog. Read [this](https://kyma-project.io/docs/1.3/components/service-catalog/#details-experimental-features) document to learn how to activate this feature. Moreover, the new mode contains a migration tool that migrates data for you. To learn more about the migration process, read [this](https://github.com/kyma-incubator/service-catalog/blob/crds-migration/docs/migration-apiserver-to-crds.md) document.
+Now you can configure Kyma to use the experimental "CRD only" mode of our Service Catalog. Read [this](/docs/components/service-catalog/#details-experimental-features) document to learn how to activate this feature. Moreover, the new mode contains a migration tool that migrates data for you. To learn more about the migration process, read [this](https://github.com/kyma-incubator/service-catalog/blob/crds-migration/docs/migration-apiserver-to-crds.md) document.
 
->**NOTE:** Before you start the migration, make sure that you performed a full [backup](https://kyma-project.io/docs/1.3/components/backup/) of your cluster. You should also test the procedure on a testing environment first.
+>**NOTE:** Before you start the migration, make sure that you performed a full [backup](/docs/components/backup/) of your cluster. You should also test the procedure on a testing environment first.
 
 
 ## Kyma CLI
@@ -131,7 +131,7 @@ If you need to add troubleshooting documentation to your component, our content 
 
 ### Upgrade process documentation
 
-Upgrading Kyma to a new version is quick and really simple, and release 1.3 comes with documentation to back this claim. Follow the procedure described in the [Upgrade Kyma](https://kyma-project.io/docs/1.3/root/kyma/#installation-update-kyma) document to quickly migrate to a newer release.
+Upgrading Kyma to a new version is quick and really simple, and release 1.3 comes with documentation to back this claim. Follow the procedure described in the [Upgrade Kyma](/docs/root/kyma/#installation-update-kyma) document to quickly migrate to a newer release.
 
 
 ## Eventing
@@ -151,7 +151,7 @@ Certain properties which are no longer applicable after Knative migration have b
 
 With this release, it is possible to expose an API with authentication disabled on certain paths. It is useful for scenarios in which an API hosts public assets, such as schemas or login endpoints.
 
-To allow disabling authentication on selected paths, there is a new **triggerRule** field in the Api CRD, which contains the `excludedPaths` object that represents the paths on which authentication should be disabled. The rest of the service's paths remain secured, meaning that the authentication is enabled. You can specify a matching method for paths using `exact`,`prefix`,`suffix` and `regex`. Read [this](https://kyma-project.io/docs/1.3/components/api-gateway/#custom-resource-custom-resource) document for more details.
+To allow disabling authentication on selected paths, there is a new **triggerRule** field in the Api CRD, which contains the `excludedPaths` object that represents the paths on which authentication should be disabled. The rest of the service's paths remain secured, meaning that the authentication is enabled. You can specify a matching method for paths using `exact`,`prefix`,`suffix` and `regex`. Read [this](/docs/components/api-gateway/#custom-resource-custom-resource) document for more details.
 
 ### Known issues
 

--- a/content/blog-posts/2019-08-08-release-notes-1.4/index.md
+++ b/content/blog-posts/2019-08-08-release-notes-1.4/index.md
@@ -41,7 +41,7 @@ Read about known issues for [Velero](#known-issues).
 
 ## API Gateway
 
-Making friends in the open-source world is natural. Collaboration with our friend, ORY, in the 1.4 release bore fruit, and Kyma got its very own OAuth2 server. Our new component consists of three elements from ORY: Hydra OAuth2 server, Oathkeeper proxy, and Oathkeeper Maester controller. By default, the solution is now installed with every Kyma deployment. We worked closely with ORY developers to make their solution Kubernetes-native. We achieved that by creating the Maester controller and contributing it to the ORY stack. This controller allows for convenient management of Access Rules through custom resources. Check out and test the Kyma-ORY integration and follow its development closely as we're still in the development phase. Read [this](https://kyma-project.io/blog/2019/7/31/kyma-collaboration-with-ory/) blog post to see where we're heading. Also, read the [**Security**](https://kyma-project.io/docs/1.4/components/security/#details-oauth2-and-openid-connect-server) documentation to get more details on the current state of the integration.
+Making friends in the open-source world is natural. Collaboration with our friend, ORY, in the 1.4 release bore fruit, and Kyma got its very own OAuth2 server. Our new component consists of three elements from ORY: Hydra OAuth2 server, Oathkeeper proxy, and Oathkeeper Maester controller. By default, the solution is now installed with every Kyma deployment. We worked closely with ORY developers to make their solution Kubernetes-native. We achieved that by creating the Maester controller and contributing it to the ORY stack. This controller allows for convenient management of Access Rules through custom resources. Check out and test the Kyma-ORY integration and follow its development closely as we're still in the development phase. Read [this](/blog/2019/7/31/kyma-collaboration-with-ory/) blog post to see where we're heading. Also, read the [**Security**](/docs/components/security/#details-oauth2-and-openid-connect-server) documentation to get more details on the current state of the integration.
 
 ## Application Connector
 
@@ -57,7 +57,7 @@ The backup component, Velero, is now upgraded to its latest stable version 1.0.0
 
 ### Installation and setup
 
-We improved and simplified the installation and setup process for Velero. Read the [documentation](https://kyma-project.io/docs/1.4/components/backup/#installation-install-velero) and see how easy it is now to set up Velero either before or after installing Kyma.
+We improved and simplified the installation and setup process for Velero. Read the [documentation](/docs/components/backup/#installation-install-velero) and see how easy it is now to set up Velero either before or after installing Kyma.
 
 ### Creating backups
 
@@ -73,7 +73,7 @@ All backup and restore integration tests are fixed and pass.
 
 ### Backups on Azure
 
-The backup functionality was successfully introduced on Azure (AKS). Follow the steps from the [installation](https://kyma-project.io/docs/1.4/components/backup/#installation-install-velero) guide to set up Velero on Azure.
+The backup functionality was successfully introduced on Azure (AKS). Follow the steps from the [installation](/docs/components/backup/#installation-install-velero) guide to set up Velero on Azure.
 
 ### Plugins
 
@@ -106,7 +106,7 @@ It basically means that at the moment we have 4 different views that render docu
 
 - Documentation component project
 
-As mentioned in the [previous release notes](https://kyma-project.io/blog/2019/7/12/release-notes-13/#documentation-component), we have one single project in which we maintain the Documentation component and just reuse it in different applications. We already introduced it in the Console UI Documentation view in the last release. In the 1.4 release, it was integrated into the Console UI Catalog and Instances views. In a few days, you will see this component being used on [kyma-project.io](https://kyma-project.io/).
+As mentioned in the [previous release notes](/blog/2019/7/12/release-notes-13/#documentation-component), we have one single project in which we maintain the Documentation component and just reuse it in different applications. We already introduced it in the Console UI Documentation view in the last release. In the 1.4 release, it was integrated into the Console UI Catalog and Instances views. In a few days, you will see this component being used on [kyma-project.io](https://kyma-project.io/).
 
 - Improved look and feel
 
@@ -146,7 +146,7 @@ data:
   global.cmsAsyncAPIService.enabled: "true"
 ```
 
-After you override the value, you can create a DocsTopic resource using [this](https://kyma-project.io/docs/1.4/components/headless-cms/#custom-resource-docs-topic-sample-custom-resource) example. The example contains a reference to the official Slack AsyncAPI spec provided in version 1.2. After you go through the steps for the happy path, create a new DocsTopic using an invalid spec. You can use the [invalid AsyncAPI spec](https://raw.githubusercontent.com/kyma-project/kyma/release-1.4/components/cms-services/pkg/endpoint/asyncapi/v1/testdata/invalid.json) we used for testing.
+After you override the value, you can create a DocsTopic resource using [this](/docs/components/headless-cms/#custom-resource-docs-topic-sample-custom-resource) example. The example contains a reference to the official Slack AsyncAPI spec provided in version 1.2. After you go through the steps for the happy path, create a new DocsTopic using an invalid spec. You can use the [invalid AsyncAPI spec](https://raw.githubusercontent.com/kyma-project/kyma/release-1.4/components/cms-services/pkg/endpoint/asyncapi/v1/testdata/invalid.json) we used for testing.
 
 ### Parameters object in the Headless CMS supported in the Console UI
 
@@ -186,7 +186,7 @@ We added an integrated authentication strategy to the Kiali dashboard to enable 
 
 ### Documentation
 
-[Kiali](https://kyma-project.io/docs/1.4/components/kiali) is now documented in the Kyma Docs.
+[Kiali](/docs/components/kiali) is now documented in the Kyma Docs.
 
 ## Knative
 
@@ -220,7 +220,7 @@ As the Google Cloud Platform (GCP) Service Broker is being deprecated by Google,
 
 ### Helm Broker supports addons exposed by Git
 
-Starting from this release, you can expose your addons not only through HTTPS serves but also using Git. To do so, simply place your addons directly in a Git directory and follow the necessary addon repository structure. Read [this](https://kyma-project.io/docs/1.4/components/helm-broker/#details-create-addons-repository) document to learn more.
+Starting from this release, you can expose your addons not only through HTTPS serves but also using Git. To do so, simply place your addons directly in a Git directory and follow the necessary addon repository structure. Read [this](/docs/components/helm-broker/#details-create-addons-repository) document to learn more.
 
 ## Service Mesh
 

--- a/content/blog-posts/2019-09-09-release-notes-1.5/index.md
+++ b/content/blog-posts/2019-09-09-release-notes-1.5/index.md
@@ -33,11 +33,11 @@ In the 1.5 release, we made sure that Kyma is compatible with Kubernetes 1.15. N
 
 ### Kubernetes-native client registration with the Hydra Maester controller
 
-Our collaboration with ORY that started in the previous release continues with new contribution and functionality. This time around, we created the Hydra Maester controller which makes registering OAuth2 clients a fully Kubernetes-native process. The controller listens for instances of the `oauth2clients.hydra.ory.sh` custom resource (CR) and registers clients through the Hydra API using the data contained in the CR. Credentials of the registered client are then saved in a Kubernetes Secret. Follow [this](https://github.com/ory/hydra-maester) link to visit the ORY Hydra Maester repository and read [this](https://kyma-project.io/docs/1.5/components/security/#details-o-auth2-and-open-id-connect-server) document to learn more about the ORY stack implementation in Kyma.
+Our collaboration with ORY that started in the previous release continues with new contribution and functionality. This time around, we created the Hydra Maester controller which makes registering OAuth2 clients a fully Kubernetes-native process. The controller listens for instances of the `oauth2clients.hydra.ory.sh` custom resource (CR) and registers clients through the Hydra API using the data contained in the CR. Credentials of the registered client are then saved in a Kubernetes Secret. Follow [this](https://github.com/ory/hydra-maester) link to visit the ORY Hydra Maester repository and read [this](/docs/components/security/#details-o-auth2-and-open-id-connect-server) document to learn more about the ORY stack implementation in Kyma.
 
 ### New API Gateway controller in the Incubator
 
-Another fruit of the Kyma-ORY collaboration, the API Gateway controller (name subject to change!), is available in the Kyma Incubator. This controller listens for instances of the `gate.gateway.kyma-project.io` CR, manages Istio authentication policies and Oathkeeper rules, and allows you to expose services secured with JWT or OAuth access tokens. Even though this controller is still in the early stages of development and cannot replace the existing Kyma API Gateway, you can install it with your Kyma deployment by uncommenting the appropriate entry on the component list before installing Kyma 1.5. Go to [this](https://github.com/kyma-incubator/api-gateway) Incubator repository to learn more about the controller and read [this](https://kyma-project.io/docs/1.5/root/kyma/#configuration-custom-component-installation) document to learn more about installing selected components.
+Another fruit of the Kyma-ORY collaboration, the API Gateway controller (name subject to change!), is available in the Kyma Incubator. This controller listens for instances of the `gate.gateway.kyma-project.io` CR, manages Istio authentication policies and Oathkeeper rules, and allows you to expose services secured with JWT or OAuth access tokens. Even though this controller is still in the early stages of development and cannot replace the existing Kyma API Gateway, you can install it with your Kyma deployment by uncommenting the appropriate entry on the component list before installing Kyma 1.5. Go to [this](https://github.com/kyma-incubator/api-gateway) Incubator repository to learn more about the controller and read [this](/docs/root/kyma/#configuration-custom-component-installation) document to learn more about installing selected components.
 
 ## Application Connector
 
@@ -62,9 +62,9 @@ In previous Kyma versions, it was only possible to configure cluster-wide addons
 Based on the existing [`monitoring-custom-metrics`](https://github.com/kyma-project/examples/tree/master/monitoring-custom-metrics) Kyma example and its `cpu_temperature_celsius` custom metric, we have created unified monitoring tutorials. Thanks to them you can see how Kyma applies monitoring tools to manage application metrics. More specifically, these tutorials show how you can observe the custom metric's changing values, create a Grafana dashboard for the metric, and set up a corresponding alerting rule for it.
 
 Follow these links to see the improved monitoring tutorials:
-- [Observe application metrics](https://kyma-project.io/docs/1.5/components/monitoring/#tutorials-observe-application-metrics)
-- [Create a Grafana dashboard](https://kyma-project.io/docs/1.5/components/monitoring/#tutorials-create-a-grafana-dashboard)
-- [Define alerting rules](https://kyma-project.io/docs/1.5/components/monitoring/#tutorials-define-alerting-rules)
+- [Observe application metrics](/docs/components/monitoring/#tutorials-observe-application-metrics)
+- [Create a Grafana dashboard](/docs/components/monitoring/#tutorials-create-a-grafana-dashboard)
+- [Define alerting rules](/docs/components/monitoring/#tutorials-define-alerting-rules)
 
 ### Telepresence guide
 
@@ -72,17 +72,17 @@ We know how difficult of a task developing and debugging locally can be. That is
 
 ### Troubleshooting guides for the Application Connector
 
-We provided a set of [troubleshooting guides](https://kyma-project.io/docs/1.5/components/application-connector/#troubleshooting-troubleshooting) that will help you to resolve the most common issues you may encounter when interacting with such components as the Application Gateway, Application Registry, and Connector Service.
+We provided a set of [troubleshooting guides](/docs/components/application-connector/#troubleshooting-troubleshooting) that will help you to resolve the most common issues you may encounter when interacting with such components as the Application Gateway, Application Registry, and Connector Service.
 
 ## Service Management
 
 ### Separate repository for the Helm Broker
 
-The Helm Broker now has its own [separate repository](https://github.com/kyma-project/helm-broker) in the `kyma-project` organization. We have not changed the location of the related documentation so you can still read about the Helm Broker [here](https://kyma-project.io/docs/components/helm-broker/).
+The Helm Broker now has its own [separate repository](https://github.com/kyma-project/helm-broker) in the `kyma-project` organization. We have not changed the location of the related documentation so you can still read about the Helm Broker [here](/docs/components/helm-broker/).
 
 ### Support authentication methods for addons configurations
 
-Starting from the 1.5 release, we support fetching addons from repositories that require authentication. You can now pass credentials in a secure way using templates in your repository's URL. For more information, read [this](https://kyma-project.io/docs/1.5/components/helm-broker/#details-create-addons-repository-authorization) document.  
+Starting from the 1.5 release, we support fetching addons from repositories that require authentication. You can now pass credentials in a secure way using templates in your repository's URL. For more information, read [this](/docs/components/helm-broker/#details-create-addons-repository-authorization) document.  
 
 ## Serverless
 


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- We remove from kyma-project.io documentation for version older than 1.6 so in blog posts we need to fix link to point to default location instead of the specific release version
