### PR TITLE
Add command line for cert-import on linux.

### DIFF
--- a/content/docs/master/kyma/docs/04-03-cluster-installation.md
+++ b/content/docs/master/kyma/docs/04-03-cluster-installation.md
@@ -234,7 +234,15 @@ After the installation, add the custom Kyma [`xip.io`](http://xip.io/) self-sign
   && kubectl get configmap net-global-overrides -n kyma-installer -o jsonpath='{.data.global\.ingress\.tlsCrt}' | base64 --decode > $tmpfile \
   && sudo security add-trusted-cert -d -r trustRoot -k /Library/Keychains/System.keychain $tmpfile \
   && rm $tmpfile
-  ```
+```
+
+For Linux with Chrome run:
+```bash
+  tmpfile=$(mktemp /tmp/temp-cert.XXXXXX) \
+  && kubectl get configmap net-global-overrides -n kyma-installer -o jsonpath='{.data.global\.ingress\.tlsCrt}' | base64 --decode > $tmpfile \
+  && certutil -d sql:$HOME/.pki/nssdb -A -t "C,," -n "My Kyma Cluster" -i $tmpfile \
+  && rm $tmpfile
+```
 
 ### Access the cluster
 


### PR DESCRIPTION
This Pull-Request add a command line to the documentation, how to import the selfsigned-certificate into the users chrome keystore on linux.
