### PR TITLE
Update wordpress-deployment.yaml

### DIFF
--- a/content/blog-posts/2019-07-08-extend-wordpress/wordpress-deployment.yaml
+++ b/content/blog-posts/2019-07-08-extend-wordpress/wordpress-deployment.yaml
@@ -81,7 +81,8 @@ metadata:
     app: wordpress
 spec:
   ports:
-    - port: 80
+    - name: http
+      port: 80
   selector:
     app: wordpress
     tier: frontend


### PR DESCRIPTION
adding spec.ports.name

Without the port name being specified as http the kyma api gateway.kyma-project.io will not resolve correctly.