### PR TITLE
Fix ownership of the content folder and its subfolders

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,6 +1,6 @@
 * @michal-hudy @aerfio @m00g3n @magicmatatjahu @pPrecel
 
-/content/* @kazydek @klaudiagrz @tomekpapiernik @bszwarc @mmitoraj @alexandra-simeonova @majakurcius
+/content/ @kazydek @klaudiagrz @tomekpapiernik @bszwarc @mmitoraj @alexandra-simeonova @majakurcius
 
 *.md @kazydek @klaudiagrz @tomekpapiernik @bszwarc @mmitoraj @alexandra-simeonova @majakurcius
 


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Fixed ownership of any content under the `content` folder in the website as `/content/*` excluded TWs from the ownership of files in the subfolders, and the default owners of the repo were requested for reviews.

