### PR TITLE
Update Website documentation CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,7 +1,7 @@
 * @aerfio @m00g3n @magicmatatjahu @pPrecel @valentinvieriu @tgorgol
 
-/content/ @kazydek @klaudiagrz @bszwarc @mmitoraj @alexandra-simeonova @majakurcius
+/content/ @kazydek @klaudiagrz @mmitoraj @alexandra-simeonova @majakurcius @superojla
 
-*.md @kazydek @klaudiagrz @bszwarc @mmitoraj @alexandra-simeonova @majakurcius
+*.md @kazydek @klaudiagrz @mmitoraj @alexandra-simeonova @majakurcius @superojla
 
 


### PR DESCRIPTION
**Description**

Since Barbara Sz. (@bszwarc) left us in September and is no longer an active contributor, she should be removed from CODEOWNERS.  
At the same time, Justyna Sz. (@superojla) joined us in September and has been contributing to Kyma documentation, so it's time to add her to CODEOWNERS. 

Changes proposed in this pull request:

- Remove @bszwarc from documentation CODEOWNERS
- Add @superojla to documentation CODEOWNERS