### PR TITLE
Fix broken links to 1.14 docs version that is no longer supported

### DIFF
--- a/content/blog-posts/2020-08-06-release-notes-1.14/index.md
+++ b/content/blog-posts/2020-08-06-release-notes-1.14/index.md
@@ -65,7 +65,7 @@ We redesigned the `install` command to make the Kyma installation process run sm
 
 ### install command supports the component list
 
-The `install` command has the new `--components` flag which you can use to define the list of components you want to install. You must provide a path to the YAML file that contains either the full [Installation custom resource](https://kyma-project.io/docs/1.14/root/kyma/#custom-resource-installation) configuration or just the components list.
+The `install` command has the new `--components` flag which you can use to define the list of components you want to install. You must provide a path to the YAML file that contains either the full [Installation custom resource](https://github.com/kyma-project/kyma/blob/release-1.14/docs/kyma/06-01-installation.md) configuration or just the components list.
 
 ### install command supports Git revisions
 
@@ -79,7 +79,7 @@ We unified Kyma documentation and made sure all installation instructions includ
 
 ### Compass separated from the Kyma installation
 
-From this release, Compass is no longer an integral part of the Kyma installation. However, Kyma still connects to Compass through the [Runtime Agent](https://kyma-project.io/docs/1.14/components/runtime-agent/). From now on, if you want to use Compass, [install Kyma with the Runtime Agent](https://kyma-project.io/docs/1.14/components/runtime-agent#installation-installation) first and then [install Compass](https://github.com/kyma-incubator/compass/blob/master/docs/compass/04-01-installation.md) separately.  
+From this release, Compass is no longer an integral part of the Kyma installation. However, Kyma still connects to Compass through the [Runtime Agent](https://github.com/kyma-project/kyma/tree/release-1.14/docs/runtime-agent). From now on, if you want to use Compass, [install Kyma with the Runtime Agent](https://github.com/kyma-project/kyma/blob/release-1.14/docs/runtime-agent/04-01-installation-modes.md) first and then [install Compass](https://github.com/kyma-incubator/compass/blob/master/docs/compass/04-01-installation.md) separately.  
 
 ## Console
 
@@ -127,7 +127,7 @@ We upgraded Grafana to v7.0 which brings a lot of improvements like a new panel 
 
 ### Serverless migrated to bare metal Kubernetes resources
 
-We continue our work on the Serverless Runtime for Kyma. In this release, we migrated from Knative Serving to pure Kubernetes resources. In its new shape and form, Serverless is more lightweight, doesn't require any additional components, and provides more control over underlying resources. With this change, Serverless uses only Jobs, Deployments, Services, and Horizontal Pod Autoscalers. To see how all these pieces fit together, take a look at the [Serverless architecture](https://kyma-project.io/docs/1.14/components/serverless/#architecture-architecture). Importantly, the whole migration from the previous solution to the current one is fully automated and executed during Kyma update.
+We continue our work on the Serverless Runtime for Kyma. In this release, we migrated from Knative Serving to pure Kubernetes resources. In its new shape and form, Serverless is more lightweight, doesn't require any additional components, and provides more control over underlying resources. With this change, Serverless uses only Jobs, Deployments, Services, and Horizontal Pod Autoscalers. To see how all these pieces fit together, take a look at the [Serverless architecture](https://github.com/kyma-project/kyma/blob/release-1.14/docs/serverless/02-01-serverless.md). Importantly, the whole migration from the previous solution to the current one is fully automated and executed during Kyma update.
 
 ### Function CRD validation
 
@@ -141,7 +141,7 @@ We introduced the validation of Function CRDs. Every new version of the Function
 - Google Container Registry
 - Azure Container Registry
 
-We strongly recommend them for your production set-up. They are fully managed and pre-configured, making your Function images secure and backed up. Read how to [switch to an external Docker registry using overrides](https://kyma-project.io/docs/1.14/components/serverless/#tutorials-set-an-external-docker-registry).
+We strongly recommend them for your production set-up. They are fully managed and pre-configured, making your Function images secure and backed up. Read how to [switch to an external Docker registry using overrides](https://github.com/kyma-project/kyma/blob/release-1.14/docs/serverless/08-05-set-external-docker-registry.md).
 
 ### functions.kubeless.io CRD removed
 

--- a/content/blog-posts/2020-08-06-release-notes-1.14/index.md
+++ b/content/blog-posts/2020-08-06-release-notes-1.14/index.md
@@ -131,7 +131,7 @@ We continue our work on the Serverless Runtime for Kyma. In this release, we mig
 
 ### Function CRD validation
 
-We introduced the validation of Function CRDs. Every new version of the Function CRD is verified by the [defaulting and validation webhooks](https://kyma-project.io/docs/1.14/components/serverless/#details-supported-webhooks) before you apply it on your cluster. Validation works not only in the UI but also in the terminal when you apply resources using kubectl.
+We introduced the validation of Function CRDs. Every new version of the Function CRD is verified by the [defaulting and validation webhooks](https://github.com/kyma-project/kyma/blob/release-1.14/docs/serverless/03-01-supported-webhooks.md) before you apply it on your cluster. Validation works not only in the UI but also in the terminal when you apply resources using kubectl.
 
 ### External Docker registry
 


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

Since the 1.14 version of the documentation is no longer supported on the website, we need to change the links to the 1.14 version of docs stored in GitHub.

Changes proposed in this pull request:

- Fix broken links to 1.14 docs version

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
