### PR TITLE
feat: render content of links (yaml, json) in code blocks

### DIFF
--- a/content/docs/kyma/1.0/service-mesh/docs/03-01-sidecar-proxy-injection.md
+++ b/content/docs/kyma/1.0/service-mesh/docs/03-01-sidecar-proxy-injection.md
@@ -3,6 +3,12 @@ title: Sidecar Proxy Injection
 type: Details
 ---
 
+To apply the definition of OpenAPI schema, run command:
+
+```bash
+kubectl apply -f https://raw.githubusercontent.com/kyma-project/kyma/master/docs/getting-started/assets/orders-service-openapi.yaml
+```
+
 By default, the Istio sidecar injector watches all Pod creation operations on all Namespaces and injects the newly created Pods with a sidecar proxy.
 
 You can disable sidecar proxy injection for either an entire Namespace or a single Deployment.

--- a/src/components/generic-documentation/render-engines/markdown/custom-renderers/Code.tsx
+++ b/src/components/generic-documentation/render-engines/markdown/custom-renderers/Code.tsx
@@ -1,0 +1,71 @@
+import React, { useState, useEffect } from "react";
+import styled from "@styled";
+import Link from "@components/shared/Link";
+import {
+  Code as BasicCode,
+  CodeProps,
+} from "@kyma-project/dc-markdown-render-engine/lib/renderers/Code";
+
+import { findDownloadableLinks, DownloadableLink } from "../helpers";
+
+const PreviewBlock = styled.ul``;
+const SingleBlock = styled.li`
+  > p {
+    cursor: pointer;
+  }
+`;
+
+const LinkContent: React.FunctionComponent<DownloadableLink & CodeProps> = ({
+  link,
+  extension,
+  ...props
+}) => {
+  const [content, setContent] = useState("");
+  const [showPreview, setShowPreview] = useState(false);
+
+  useEffect(() => {
+    if (content) return;
+    fetch(link)
+      .then(response => response.text())
+      .then(resultData => {
+        setContent(resultData);
+      });
+  }, [showPreview]);
+
+  return (
+    <SingleBlock>
+      <p>
+        <span onClick={() => setShowPreview(!showPreview)}>
+          Show preview for{" "}
+        </span>
+        <Link.External to={link}>{link}</Link.External>
+      </p>
+      {showPreview && content && (
+        <BasicCode {...props} value={content} language={extension} />
+      )}
+    </SingleBlock>
+  );
+};
+
+export const Code: React.FunctionComponent<CodeProps> = ({
+  children,
+  ...props
+}) => {
+  const code = (children ? children : props.value) as string;
+  if (!code) {
+    return null;
+  }
+
+  const links = findDownloadableLinks(code);
+  const linksExist = links.length > 0;
+  const renderedLinks = links.map(link => (
+    <LinkContent key={link.link} {...link} {...props} />
+  ));
+
+  return (
+    <>
+      <BasicCode {...props}>{children}</BasicCode>
+      {linksExist && <PreviewBlock>{renderedLinks}</PreviewBlock>}
+    </>
+  );
+};

--- a/src/components/generic-documentation/render-engines/markdown/custom-renderers/index.ts
+++ b/src/components/generic-documentation/render-engines/markdown/custom-renderers/index.ts
@@ -1,3 +1,4 @@
+export * from "./Code";
 export * from "./Image";
 export * from "./Heading";
 export * from "./Link";

--- a/src/components/generic-documentation/render-engines/markdown/helpers/findDownloadableLinks.ts
+++ b/src/components/generic-documentation/render-engines/markdown/helpers/findDownloadableLinks.ts
@@ -1,0 +1,21 @@
+const linkRegexp = /(https?:\/\/(?:www\.|(?!www))[^\s\.]+\.[^\s]{2,}|www\.[^\s]+\.[^\s]{2,})/gi;
+const supportedExts = ["yml", "yaml", "json"];
+
+export interface DownloadableLink {
+  link: string;
+  extension: string;
+}
+
+export function findDownloadableLinks(source: string): DownloadableLink[] {
+  const matches = source.match(linkRegexp) || [];
+  return matches
+    .map(link => {
+      const ext = link.split(".").pop() || "";
+      if (!supportedExts.includes(ext)) return;
+      return {
+        link,
+        extension: ext,
+      };
+    })
+    .filter(Boolean) as DownloadableLink[];
+}

--- a/src/components/generic-documentation/render-engines/markdown/helpers/index.ts
+++ b/src/components/generic-documentation/render-engines/markdown/helpers/index.ts
@@ -2,3 +2,4 @@ export * from "./scrollSpyCallback";
 export * from "./customFirstNode";
 export * from "./headingPrefix";
 export * from "./postProcessingHeaders";
+export * from "./findDownloadableLinks";

--- a/src/components/generic-documentation/render-engines/markdown/index.tsx
+++ b/src/components/generic-documentation/render-engines/markdown/index.tsx
@@ -8,11 +8,10 @@ import {
   markdownRenderEngine,
   MarkdownRenderEngineOptions,
 } from "@kyma-project/dc-markdown-render-engine";
-
 import { ImageSpec } from "../../../../../gatsby/types";
 import { Specification } from "@typings/docs";
 
-import { Image, Link, Heading, CopyButton } from "./custom-renderers";
+import { Code, Image, Link, Heading, CopyButton } from "./custom-renderers";
 import { tabsParserPlugin } from "./plugins";
 import { highlightTheme } from "./highlightTheme";
 import { headingPrefix } from "./helpers";
@@ -36,6 +35,13 @@ export const markdownRE = (
         image: (props: any) => <Image {...props} imagesSpec={imagesSpec} />,
         link: (props: any) => (
           <Link {...props} specifications={specifications} layout={layout} />
+        ),
+        code: (props: any) => (
+          <Code
+            {...props}
+            highlightTheme={highlightTheme}
+            copyButton={CopyButton}
+          />
         ),
         heading: Heading,
       },


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

Render content of links (at the moment only yaml, json) in code blocks:
- only yamls and jsons, because I think that it's only valid files to render in Kyma's website. Render `.sh` etc. files is unnecessary.
- content of links are downloaded in runtime, it means when user visit the page, not on building time,
- add in docs mock link to test feature
- css will be corrected after the first review/discussion, whether the logic are pleasing by the maintainers :)
- I think that after merging this PR, [this](https://github.com/kyma-project/kyma/pull/10198) PR can be finished.

**Related issue(s)**
Resolves https://github.com/kyma-project/website/issues/657