### PR TITLE
Add Twitter links to ignored to get rid of Bad Request errors

### DIFF
--- a/milv.config.yaml
+++ b/milv.config.yaml
@@ -2,6 +2,7 @@ white-list-external:
   - localhost
   - kyma.local
   - http://xip.io
+  - https://twitter.com/*
 black-list:
   - node_modules
   - content/docs


### PR DESCRIPTION
**Description**

Recently, the dead link checker's calls to Twitter links used in our Kyma blog posts returned `400 Bad Request`, even though the links are working just fine. It is possible that the subsequent calls are being made too fast and Twitter rejects those calls. 
A workaround to prevent these false positives from appearing in the logs is to add Twitter links to the "ignored" list.

Changes proposed in this pull request:

- Add Twitter links to ignored to fix `40 Bad Request` false positives

**Related issues (logs)**
- [2021-01-25 - website-governance-nightly #1353583514263490561](https://status.build.kyma-project.io/view/gcs/kyma-prow-logs/logs/website-governance-nightly/1353583514263490561)
- [2021-01-26 - website-governance-nightly #1353945921049595905](https://status.build.kyma-project.io/view/gcs/kyma-prow-logs/logs/website-governance-nightly/1353945921049595905)
- [2021-01-27 - website-governance-nightly #1354308312996253697](https://status.build.kyma-project.io/view/gcs/kyma-prow-logs/logs/website-governance-nightly/1354308312996253697)
- [2021-01-28 - website-governance-nightly #1354670704196325381](https://status.build.kyma-project.io/view/gcs/kyma-prow-logs/logs/website-governance-nightly/1354670704196325381)
- [2021-01-29 - website-governance-nightly #1355033095476088833](https://status.build.kyma-project.io/view/gcs/kyma-prow-logs/logs/website-governance-nightly/1355033095476088833)
