### PR TITLE
Install minikube so that the getting started example works directly

### DIFF
--- a/src/views/landingPage/WhatIs/Termynal/Termynal.tsx
+++ b/src/views/landingPage/WhatIs/Termynal/Termynal.tsx
@@ -4,7 +4,7 @@ import { TermynalStyles } from "./styled";
 export const Termynal: FC = () => (
   <TermynalStyles>
     <div id="termynal" data-termynal={true}>
-      <span data-ty="input">brew install kyma-cli</span>
+      <span data-ty="input">brew install kyma-cli minikube</span>
       <span data-ty="input">kyma provision minikube</span>
       <span data-ty="input">kyma install</span>
       <span data-ty={true}>Installation successful! Happy Kyma-ing :)</span>


### PR DESCRIPTION
The getting started snippet on the landing page requires Minikube
to be already installed.

If this is not the case, the call to kyma provision minikube will
fail.

$ kyma provision minikube
X Checking requirements
Error: Executing the 'minikube version' command with output '' and
error message 'exec: "minikube": executable file not found in $PATH'
failed

For the example to work directly, Minikube should also be installed.

Signed-off-by: Christian Berendt <berendt@23technologies.cloud>