### PR TITLE
Remove kazydek from CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,5 +1,5 @@
 * @m00g3n @pPrecel @valentinvieriu @dbadura @tgorgol @rJankowski93
 
-/content/ @kazydek @klaudiagrz @mmitoraj @alexandra-simeonova @majakurcius @NHingerl
+/content/ @klaudiagrz @mmitoraj @alexandra-simeonova @majakurcius @NHingerl
 
-*.md @kazydek @klaudiagrz @mmitoraj @alexandra-simeonova @majakurcius @NHingerl
+*.md @klaudiagrz @mmitoraj @alexandra-simeonova @majakurcius @NHingerl


### PR DESCRIPTION
**Description**

As Karolina is no longer an active contributor to the project, she must be removed from the CODEOWNERS.

Changes proposed in this pull request:

- Remove **kazydek** from CODEOWNERS