### PR TITLE
Add the link to the OS Kyma Slack to Ignored to stop false 404s

### DIFF
--- a/milv.config.yaml
+++ b/milv.config.yaml
@@ -3,6 +3,8 @@ external-links-to-ignore:
   - kyma.local
   - http://xip.io
   - https://twitter.com/*
+  - http://slack.kyma-project.io
+  - http://slack.kyma-project.io/
 files-to-ignore:
   - node_modules
   - content/docs


### PR DESCRIPTION
The link to the OS Kyma Slack channel (http://slack.kyma-project.io) has recently started returning the `404 Not Found` error for MILV, but the link in fact works, therefore it needs to be added to the Ignored list for now to get rid of those false 404s.

**Description**

Changes proposed in this pull request:

- Add `http://slack.kyma-project.io` to the Ignored list for MILV.

**Related issue(s)**
https://github.com/kyma-incubator/milv/issues/12
