### PR TITLE
Add grego952 as a documentation CODEOWNER in Website

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,5 +1,5 @@
 * @m00g3n @pPrecel @valentinvieriu @dbadura 
 
-/content/ @klaudiagrz @mmitoraj @alexandra-simeonova @majakurcius @NHingerl
+/content/ @klaudiagrz @mmitoraj @alexandra-simeonova @majakurcius @NHingerl @grego952
 
-*.md @klaudiagrz @mmitoraj @alexandra-simeonova @majakurcius @NHingerl
+*.md @klaudiagrz @mmitoraj @alexandra-simeonova @majakurcius @NHingerl @grego952


### PR DESCRIPTION
**Description**

As @grego952 has been working with Kyma for over 3 months as a Technical Writer and has gained expertise in this domain, he should be added to the documentation CODEOWNERS.

Changes proposed in this pull request:

- Add @grego952 to Website documentation CODEOWNERS

**Related issue**
[#13077 ](https://github.com/kyma-project/kyma/issues/13077)
