### PR TITLE
Change the Website links to Kyma 2.0 docs to GitHub links

### DIFF
--- a/content/blog-posts/2021-12-07-release-notes-2.0/index.md
+++ b/content/blog-posts/2021-12-07-release-notes-2.0/index.md
@@ -14,7 +14,7 @@ We are happy to announce the release of Kyma 2.0! This major release brings a lo
 
 <!-- overview -->
 
-> **CAUTION:** In this release, authentication and authorization methods in Kyma have changed. Before upgrading to Kyma 2.0, read the [Migration Guide](https://kyma-project.io/docs/kyma/2.0/migration-guide-1.24-2.0).
+> **CAUTION:** In this release, authentication and authorization methods in Kyma have changed. Before upgrading to Kyma 2.0, read the [Migration Guide](https://github.com/kyma-project/kyma/blob/release-2.0/docs/migration-guide-1.24-2.0.md).
 
 See the overview of all changes in this release:
 
@@ -34,7 +34,7 @@ See the overview of all changes in this release:
 
 ### Exposing workloads on custom domains
 
-Kyma 2.0 allows you to expose Istio workloads using custom, user-managed domains. In previous Kyma versions, the only supported scenario was to use the main Kyma domain for API exposure. Now, provided you own a domain, you can expose any Kyma-hosted workload using your domain. In addition, a TLS certificate can be automatically generated for you. You can have multiple workloads using multiple custom domains. Read how to [use a custom domain to expose a service](https://kyma-project.io/docs/kyma/2.0/03-tutorials/00-api-exposure/apix-01-own-domain/) for details.
+Kyma 2.0 allows you to expose Istio workloads using custom, user-managed domains. In previous Kyma versions, the only supported scenario was to use the main Kyma domain for API exposure. Now, provided you own a domain, you can expose any Kyma-hosted workload using your domain. In addition, a TLS certificate can be automatically generated for you. You can have multiple workloads using multiple custom domains. Read how to [use a custom domain to expose a service](https://github.com/kyma-project/kyma/blob/release-2.0/docs/03-tutorials/00-api-exposure/apix-01-own-domain.md) for details.
 
 ## Application Connectivity
 
@@ -54,7 +54,6 @@ The changes allow us to drop per-application deployments (Gateways and Validator
 
 With these changes, some of the components, such as Application Operator, will become obsolete. We will remove them in the following releases. This, however, will have no effect on the existing functionality.
 
-
 ## CLI
 
 ### Switch from Minikube to k3d
@@ -71,7 +70,7 @@ The commands for installation have been updated as well:
 
 ### Values instead of configuration overrides
 
-Instead of the deprecated `--override` flag, we now use the `deploy` command to change Kyma settings. With the `--values-file` flag, you can change Kyma settings by providing a plain YAML file. Alternatively, you can provide values inline with the `--value` flag. Learn more in [Change Kyma Settings](https://kyma-project.io/docs/kyma/2.0/04-operation-guides/operations/03-change-kyma-config-values/).
+Instead of the deprecated `--override` flag, we now use the `deploy` command to change Kyma settings. With the `--values-file` flag, you can change Kyma settings by providing a plain YAML file. Alternatively, you can provide values inline with the `--value` flag. Learn more in [Change Kyma Settings](https://github.com/kyma-project/kyma/blob/release-2.0/docs/04-operation-guides/operations/03-change-kyma-config-values.md).
 
 ### The `kyma test` command deprecated
 
@@ -152,7 +151,7 @@ With the deprecation of Dex, authentication for the Observability user interface
 
 As a result, all users are logged on anonymously and see the same UI. If you prefer a user-specific configuration for Grafana UI, use the Grafana log-in solution and switch off the OAuth proxy.
 
-Read our documentation to learn how to [expose services securely](https://kyma-project.io/docs/kyma/2.0/04-operation-guides/security/sec-06-access-expose-kiali-grafana/).
+Read our documentation to learn how to [expose services securely](https://github.com/kyma-project/kyma/blob/release-2.0/docs/04-operation-guides/security/sec-06-access-expose-kiali-grafana.md).
 
 ### Improved security for logs in Kyma Dashboard
 
@@ -164,7 +163,7 @@ With the update of Fluent Bit to version 1.8, we activated the new multiline sup
 
 ### Prometheus mTLS
 
-By enabling Prometheus mTLS, you can improve the security in your Service Mesh and keep the strict mTLS mode for custom metrics. You don't have to weaken the authentication policy when you are scraping workloads deployed in the Service Mesh. Learn more in [Enable mTLS for custom metrics](https://kyma-project.io/docs/kyma/2.0/01-overview/main-areas/observability/obsv-03-istio-monitoring/#enable-m-tls-for-custom-metrics).
+By enabling Prometheus mTLS, you can improve the security in your Service Mesh and keep the strict mTLS mode for custom metrics. You don't have to weaken the authentication policy when you are scraping workloads deployed in the Service Mesh. Learn more in [Enable mTLS for custom metrics](https://github.com/kyma-project/kyma/blob/release-2.0/docs/01-overview/main-areas/observability/obsv-03-istio-monitoring.md).
 
 ### Observability services updated
 
@@ -218,7 +217,6 @@ Note that with the Service Catalog removal, it will no longer be possible to man
 
 The Service Catalog removal will also affect [Application Connectivity](#application-connectivity) in Kyma. Service Catalog objects will not be used anymore, and both ServiceInstances and ServiceBindings will not be required.
 
-
 ## Website
 
 ### New landing page
@@ -227,7 +225,7 @@ The [Kyma website](https://kyma-project.io/) now has a brand new landing page. T
 
 ### New documentation structure
 
-We restructured the [Kyma documentation](https://kyma-project.io/docs/kyma/2.0/) quite significantly in the 2.0 release. We no longer divide the left navigation based on Kyma components. Instead, it's structured based on the tasks you would normally face when using Kyma. We split rather long documents into shorter, more digestible chunks. On top of that, the collapsible tabs in the left navigation panel group the content into categories that help you find answers to your questions faster.
+We restructured the [Kyma documentation](https://github.com/kyma-project/kyma/tree/release-2.0/docs) quite significantly in the 2.0 release. We no longer divide the left navigation based on Kyma components. Instead, it's structured based on the tasks you would normally face when using Kyma. We split rather long documents into shorter, more digestible chunks. On top of that, the collapsible tabs in the left navigation panel group the content into categories that help you find answers to your questions faster.
 
 ### Roadmap removed
 


### PR DESCRIPTION
**Description**

This PR fixes broken links in the Kyma 2.0 release notes changing them from links to the Website to links to GitHub. 

Changes proposed in this pull request:

- Change the links to documentation in the [Kyma 2.0 release notes](https://kyma-project.io/blog/2021/12/7/release-notes-20/) to GitHub ones

**Related issue(s)**
https://status.build.kyma-project.io/view/gs/kyma-prow-logs/logs/website-governance-nightly/1508323142634835968 
#840 
