### PR TITLE
Fix broken links to Busola Migrator and Minikube 0.33.0

### DIFF
--- a/content/blog-posts/2019-02-14-release-notes-0.7/index.md
+++ b/content/blog-posts/2019-02-14-release-notes-0.7/index.md
@@ -110,7 +110,7 @@ As a result of continuous Kyma-Knative integration, you can now deploy Kyma with
 
 ### Upgrade to Minikube v0.33.0
 
-We have upgraded Minikube to version [0.33.0](https://github.com/kubernetes/minikube/blob/master/CHANGELOG.md#version-0330---2019-01-17). This means we can now use the stable `kubeadm` bootstrapper instead of the deprecated `localkube`. This helps us to leverage new features and improves the stability of local installations.
+We have upgraded Minikube to version [0.33.0](https://github.com/kubernetes/minikube/releases/tag/v0.33.0). This means we can now use the stable `kubeadm` bootstrapper instead of the deprecated `localkube`. This helps us to leverage new features and improves the stability of local installations.
 
 ### Upgrade to Kubernetes v1.11.5
 

--- a/content/blog-posts/2021-04-29-release-notes-1.22/index.md
+++ b/content/blog-posts/2021-04-29-release-notes-1.22/index.md
@@ -51,7 +51,7 @@ Following [good practices from GitHub](https://github.com/github/renaming), we a
 - `kyma-project` organization:
   - [`api-gateway`](https://github.com/kyma-project/api-gateway)
   - [`busola`](https://github.com/kyma-project/busola)
-  - [`busola-migrator`](https://github.com/kyma-project/busola-migrator)
+  - [`busola-migrator`](https://github.com/kyma-project/kyma/pull/15414/files)
   - [`cli`](https://github.com/kyma-project/cli)
   - [`community`](https://github.com/kyma-project/community)
   - [`control-plane`](https://github.com/kyma-project/control-plane)


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Fix the link to the Minikube 0.33.0 Release Notes in RNs for Kyma 0.7
- Replace the link to the `kyma-project/busola-migrator` repo, which has been removed, with the link to the PR where its actual code was removed in RNs for Kyma 1.22

**Related issue**
https://status.build.kyma-project.io/view/gs/kyma-prow-logs/logs/website-governance-nightly/1569204217019633664
