### PR TITLE
Add missing quotation marks to recent blog posts' metadata and references to minors

### DIFF
--- a/content/blog-posts/2022-08-25-release-notes-2.6/index.md
+++ b/content/blog-posts/2022-08-25-release-notes-2.6/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Kyma 2.6"
 author:
-  name: Andreas Thaler, PO @Kyma, and Grzegorz Karaluch, Technical Writer @Kyma"
+  name: "Andreas Thaler, PO @Kyma, and Grzegorz Karaluch, Technical Writer @Kyma"
 tags:
   - release-notes 
 type: release 

--- a/content/blog-posts/2022-09-21-observability-strategy/index.md
+++ b/content/blog-posts/2022-09-21-observability-strategy/index.md
@@ -1,7 +1,7 @@
 ---
 title: "From Observability to Telemetry – a strategy shift in Kyma"
 author:
-  name: Andreas Thaler, PO @Kyma"
+  name: "Andreas Thaler, PO @Kyma"
 tags:
   - kyma
   - observability

--- a/content/blog-posts/2022-09-22-release-notes-2.6.3/index.md
+++ b/content/blog-posts/2022-09-22-release-notes-2.6.3/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Kyma 2.6.3"
 author:
-  name: Magdalena Stręk, PO @Kyma, and Maja Szostok, Technical Writer @Kyma"
+  name: "Magdalena Stręk, PO @Kyma, and Maja Szostok, Technical Writer @Kyma"
 tags:
   - release-notes 
 type: release 

--- a/content/blog-posts/2022-09-22-release-notes-2.6.3/index.md
+++ b/content/blog-posts/2022-09-22-release-notes-2.6.3/index.md
@@ -18,7 +18,7 @@ redirectFrom:
 ## API Gateway 
  
 In Kyma 2.6 we introduced a new version of the APIRule custom resource (CR) - `v1beta1`. Unfortunately, with this change we also introduced a bug. When an APIRule is created, it is created with certain related sub-resources, which are labeled with the version of this APIRule. These labels are used to fetch the sub-resources for the appropriate version when editing the APIRule. Unfortunately, due to improper adjustment of the labeling when introducing the new APIRule version, in Kyma 2.6, when the user edited an APIRule in version `v1alpha1`, sub-resources labeled with version `v1beta1` were searched instead. Because they were not found, the system recognized them as missing and created those sub-resources in version `v1beta1`, which was not the desired behavior. As a result, any calls to the exposed workload returned the `5xx` errors. This patch release fixes the problem.   
- 
- 
+
 For more details, see the [GitHub issue](https://github.com/kyma-project/api-gateway/pull/31).
 
+> **TIP:** See also [Release Notes for Kyma 2.6](https://kyma-project.io/blog/2022/8/25/release-notes-26/).

--- a/content/blog-posts/2022-09-22-release-notes-2.7/index.md
+++ b/content/blog-posts/2022-09-22-release-notes-2.7/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Kyma 2.7"
 author:
-  name: Korbinian Stoemmer, PO @Kyma, and Nina Hingerl, Technical Writer @Kyma"
+  name: "Korbinian Stoemmer, PO @Kyma, and Nina Hingerl, Technical Writer @Kyma"
 tags:
   - release-notes 
 type: release 

--- a/content/blog-posts/2022-09-26-release-notes-2.7.1/index.md
+++ b/content/blog-posts/2022-09-26-release-notes-2.7.1/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Kyma 2.7.1"
 author:
-  name: Magdalena Stręk, PO @Kyma, and Maja Szostok, Technical Writer @Kyma"
+  name: "Magdalena Stręk, PO @Kyma, and Maja Szostok, Technical Writer @Kyma"
 tags:
   - release-notes 
 type: release 

--- a/content/blog-posts/2022-09-26-release-notes-2.7.1/index.md
+++ b/content/blog-posts/2022-09-26-release-notes-2.7.1/index.md
@@ -18,7 +18,8 @@ redirectFrom:
 ## API Gateway 
  
 In Kyma 2.6 we introduced a new version of the APIRule custom resource (CR) - `v1beta1`. Unfortunately, with this change we also introduced a bug. When an APIRule is created, it is created with certain related sub-resources, which are labeled with the version of this APIRule. These labels are used to fetch the sub-resources for the appropriate version when editing the APIRule. Unfortunately, due to improper adjustment of the labeling when introducing the new APIRule version, in Kyma 2.6, when the user edited an APIRule in version `v1alpha1`, sub-resources labeled with version `v1beta1` were searched instead. Because they were not found, the system recognized them as missing and created those sub-resources in version `v1beta1`, which was not the desired behavior. As a result, any calls to the exposed workload returned the `5xx` errors. This patch release fixes the problem.   
- 
- 
+
 For more details, see the [GitHub issue](https://github.com/kyma-project/api-gateway/issues/32).
 
+
+> **TIP:** See also [Release Notes for Kyma 2.7](https://kyma-project.io/blog/2022/9/22/release-notes-27/).


### PR DESCRIPTION
**Description**

- Add missing quotation marks to recent blog posts' metadata (

  **Affected blog posts**
  https://kyma-project.io/blog/2022/8/25/release-notes-26/
  https://kyma-project.io/blog/2022/9/21/observability-strategy/
  https://kyma-project.io/blog/2022/9/22/release-notes-27/
  https://kyma-project.io/blog/2022/9/22/release-notes-263/
  https://kyma-project.io/blog/2022/9/26/release-notes-271/

- Add a note linking to the minor release's RNs in 2.6.3 and 2.7.1 patch release Release Notes